### PR TITLE
New features for controlling what's checked

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,17 @@ to differentiate the testing from the usual python files:
 
     py.test --nbval
 
-This will execute all the `.ipynb` files in the current folder. Alternatively,
-it can be executed:
+You can also specify `--nbval-lax`, which runs notebooks and checks for
+errors, but only compares the outputs of cells with a `#NBVAL_CHECK_OUTPUT`
+marker comment.
+
+    py.test --nbval-lax
+
+The commands above will execute all the `.ipynb` files in the current folder.
+Alternatively, you can execute a specific notebook:
 
     py.test --nbval my_notebook.ipynb
 
-for an specific notebook.
 If the output lines are going to be sanitized, an extra flag, `--sanitize-with`
 together with the path to a confguration file with regex expressions, must be passed,
 i.e.

--- a/documentation.ipynb
+++ b/documentation.ipynb
@@ -32,9 +32,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The py.test program doesn't usually collect notebooks for testing; by passing the `--nbval` flag at the command line, the IPython Notebook Validation plugin will collect at test notebook cells.\n",
+    "The py.test program doesn't usually collect notebooks for testing; by passing the `--nbval` flag at the command line, the IPython Notebook Validation plugin will collect and test notebook cells, comparing their outputs with those saved in the file.\n",
+    "\n",
     "```\n",
     "$ py.test --nbval my_notebook.ipynb\n",
+    "```\n",
+    "\n",
+    "There is also an option `--nbval-lax`, which collects notebooks and runs them, failing if there is an error. This mode does not check the output of cells unless they are marked with a special `#NBVAL_CHECK_OUTPUT` comment.\n",
+    "\n",
+    "```\n",
+    "$ py.test --nbval-lax my_notebook.ipynb\n",
     "```"
    ]
   },
@@ -60,9 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -104,7 +109,7 @@
     "You can validate this notebook yourself, as shown below; the outputs that you see here are stored in the ipynb file. If your system produces different outputs, the testing process will fail. Just use the following commands:\n",
     "```\n",
     "$ cd /path/to/this/notebook\n",
-    "$ py.test --ipynb documentation.ipynb --sanitize-with doc_sanitize.cfg\n",
+    "$ py.test --nbval documentation.ipynb --sanitize-with doc_sanitize.cfg\n",
     "```"
    ]
   },
@@ -132,9 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -151,9 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -177,16 +178,14 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0.5484774726012661, 0.6435546033932157, 0.10826743499682889, 0.5748413548528436]\n",
-      "[0.7290940674500538, 0.6663117586823235, 0.7182293584340027, 0.22383996412490337]\n"
+      "[0.36133679016382714, 0.5043774697891126, 0.23281910875007927, 0.2713065513128683]\n",
+      "[0.5512421277985322, 0.02592706358897756, 0.05036036771084684, 0.7515926759190724]\n"
      ]
     }
    ],
@@ -205,16 +204,12 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1\n",
-      "1\n",
       "1\n",
       "1\n",
       "1\n"
@@ -236,16 +231,14 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The time is: 22:11:51\n",
-      "Today's date is: 18/02/16\n"
+      "The time is: 15:28:30\n",
+      "Today's date is: 21/12/16\n"
      ]
     }
    ],
@@ -265,44 +258,67 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In case we want to avoid the testing process in specific input cells, we can write the comment ** #PYTEST_VALIDATE_IGNORE_OUTPUT ** at the\n",
+    "In case we want to avoid the testing process in specific input cells, we can write the comment ** #NBVAL_IGNORE_OUTPUT ** at the\n",
     "beginning of the them:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "This is not going to be tested\n",
-      "11423\n"
+      "12544\n"
      ]
     }
    ],
    "source": [
-    "#PYTEST_VALIDATE_IGNORE_OUTPUT\n",
+    "# NBVAL_IGNORE_OUTPUT\n",
     "print('This is not going to be tested')\n",
     "print(np.random.randint(1, 20000))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
+   "source": [
+    "There's also a counterpart, to ensure the output is tested even when using `--nbval-lax` :"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This will be tested\n",
+      "42\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_CHECK_OUTPUT\n",
+    "print(\"This will be tested\")\n",
+    "print(6 * 7)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Figures"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "collapsed": true
    },
@@ -322,14 +338,12 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x10eb48be0>"
+       "<matplotlib.image.AxesImage at 0x7f2cb3374198>"
       ]
      },
      "execution_count": 10,
@@ -338,9 +352,9 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAREAAAEACAYAAACUHkKwAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADkNJREFUeJzt3X+sX3V9x/Hni1X+wGonTlrtj3sNCkSzpXNJhTDWuziV\nGmP9g8xficofjhCYJv4xnCOjmCXqnzIxSoIGTIxGE6Xyw4FhVdmUEaDCFKRktrQFqgnWBDBL1ff+\nuAf97vZ+7729n3Pv+Vaej+TknnO+73s+737avjjn3E9DqgpJWq5Thm5A0snNEJHUxBCR1MQQkdTE\nEJHUxBCR1GRNyzcneQnwFWAK2A/8bVX9cp66/cAvgd8Cx6pqW8u4kiZH653IR4BvV9XZwJ3AP46p\n+y0wU1V/boBIf1haQ2QncEO3fwPw9jF16WEsSROo9S/2GVV1BKCqngTOGFNXwB1J7knygcYxJU2Q\nRd+JJLkDWD96itlQuHKe8nFr6M+vqieSvIzZMHmoqu464W4lTZxFQ6Sq3jjusyRHkqyvqiNJNgA/\nG3ONJ7qvP0/ydWAbMG+IJPEf80gDqaqc6Pc0/XQG2A28H/gk8D7gprkFSU4DTqmqp5O8EHgTcPXC\nl72qsa2+7QFmBu5hju0Ff71r6C7+v3/fNXE9XVB/xfZdFwzdxnG+s+t7E9XXZrZwSS5d1ve2vhP5\nJPDGJD8B3gB8AiDJy5Pc3NWsB+5Kcj/wA+CbVXV747iSJkTTnUhVPQX8zTznnwDe2u3/FNjaMo6k\nyeWPXZdkeugGjjc9M3QHx5vAnqZmtgzdwrwmta/lMESWZHroBo73ypmhOzjeBPY0PTM1dAvzmtS+\nlsMQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHU\nxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUpJcQSXJhkoeT\nPJLkijE11yTZl2RvEv8H39IfiOYQSXIK8GngzcBrgXclOWdOzQ7gzKp6NXAJ8NnWcSVNhj7uRLYB\n+6rqQFUdA74M7JxTsxO4EaCq7gbWJVnfw9iSBtZHiGwEDo4cH+rOLVRzeJ4aSSchX6xKarKmh2sc\nBraMHG/qzs2t2bxIzYg9I/vT3SapT/v3HODAnscAWMe6ZV+njxC5B3hVkingCeCdwLvm1OwGLgO+\nkuRc4GhVHRl/yZke2pK0kOmZKaZnpgDYzBZuvvqWZV2nOUSq6jdJLgduZ/bx6PqqeijJJbMf13VV\ndWuStyR5FHgGuLh1XEmToY87EarqW8DZc859bs7x5X2MJWmy+GJVUhNDRFITQ0RSE0NEUhNDRFIT\nQ0RSE0NEUhNDRFITQ0RSE0NEUhNDRFITQ0RSE0NEUhNDRFITQ0RSE0NEUhNDRFITQ0RSE0NEUhND\nRFITQ0RSE0NEUhNDRFITQ0RSE0NEUhNDRFITQ0RSE0NEUhNDRFKTXkIkyYVJHk7ySJIr5vl8e5Kj\nSe7rtiv7GFfS8Na0XiDJKcCngTcAjwP3JLmpqh6eU/rdqnpb63iSJksfdyLbgH1VdaCqjgFfBnbO\nU5cexpI0YfoIkY3AwZHjQ925uc5LsjfJLUle08O4kiZA8+PMEt0LbKmqZ5PsAL4BnDW2env9fn96\nO0zPrHB7J58r//mfhm7hpPCxaz8+dAsTa88jsGff7P7htZuWfZ0+QuQwsGXkeFN37neq6umR/duS\nfCbJ6VX11LxXnLmqh7YkLWTmrNkNgA2b+dhXDy3rOn08ztwDvCrJVJJTgXcCu0cLkqwf2d8GZGyA\nSDqpNN+JVNVvklwO3M5sKF1fVQ8luWT247oOuCjJpcAx4FfAO1rHlTQZenknUlXfAs6ec+5zI/vX\nAtf2MZakyeKKVUlNDBFJTQwRSU0MEUlNDBFJTQwRSU0MEUlNDBFJTQwRSU0MEUlNDBFJTQwRSU0M\nEUlNDBFJTQwRSU0MEUlNDBFJTQwRSU0MEUlNDBFJTQwRSU0MEUlNDBFJTQwRSU0MEUlNDBFJTQwR\nSU0MEUlNegmRJNcnOZLkgQVqrkmyL8neJFv7GFfS8Pq6E/kC8OZxHybZAZxZVa8GLgE+29O4kgbW\nS4hU1V3ALxYo2Qnc2NXeDaxLsr6PsSUNa7XeiWwEDo4cH+7OSTrJrRm6gXntufr3+9PbYXpmsFak\nP1R7HoE9+7qDtQcXrF3IaoXIYWDzyPGm7tz8Zq5a6X6k572Zs2Y3ADZs5mNfPbSs6/T5OJNum89u\n4L0ASc4FjlbVkR7HljSQXu5EknwJmAFemuQx4CrgVKCq6rqqujXJW5I8CjwDXNzHuJKG10uIVNW7\nl1BzeR9jSZosrliV1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHU\nxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTE\nEJHUxBCR1KSXEElyfZIjSR4Y8/n2JEeT3NdtV/YxrqThrenpOl8A/hW4cYGa71bV23oaT9KE6OVO\npKruAn6xSFn6GEvSZFnNdyLnJdmb5JYkr1nFcSWtoL4eZxZzL7Clqp5NsgP4BnDWuOILavvv9qdm\ntjA9M7XyHZ5krr7240O3cFK4+u+H7mBy7e82gBdvOrjs66xKiFTV0yP7tyX5TJLTq+qp+eq377pg\nNdqSntemuw1g0+bNfPPQoWVdp8/HmTDmvUeS9SP724CMCxBJJ5de7kSSfAmYAV6a5DHgKuBUoKrq\nOuCiJJcCx4BfAe/oY1xJw+slRKrq3Yt8fi1wbR9jSZosrliV1MQQkdTEEJHUxBCR1MQQkdTEEJHU\nxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTE\nEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHUxBCR1KQ5RJJsSnJnkh8leTDJB8fUXZNkX5K9Sba2\njitpMqzp4Rq/Bj5cVXuTrAXuTXJ7VT38XEGSHcCZVfXqJK8HPguc28PYkgbWfCdSVU9W1d5u/2ng\nIWDjnLKdwI1dzd3AuiTrW8eWNLxe34kkmQa2AnfP+WgjcHDk+DDHB42kk1BvIdI9ynwN+FB3RyLp\neaCPdyIkWcNsgHyxqm6ap+QwsHnkeFN3bl7f2fW93+1PzWxhemaqjzYljdjfbQAvPnhwfOEiegkR\n4PPAj6vqU2M+3w1cBnwlybnA0ao6Mu5i23dd0FNbksaZ7jaATZs3881Dh5Z1neYQSXI+8B7gwST3\nAwV8FJgCqqquq6pbk7wlyaPAM8DFreNKmgzNIVJV/wH80RLqLm8dS9LkccWqpCaGiKQmhoikJoaI\npCaGiKQmhoikJoaIpCaGiKQmhoikJoaIpCaGiKQmhoikJoaIpCaGiKQmhoikJoaIpCaGiKQmhoik\nJoaIpCaGiKQmhoikJoaIpCaGiKQmhoikJoaIpCaGiKQmhoikJoaIpCbNIZJkU5I7k/woyYNJPjhP\nzfYkR5Pc121Xto4raTL0cSfya+DDVfVa4DzgsiTnzFP33ap6Xbf9Sw/jrpr9ew4M3cJx9uwbuoPj\nTWJP+4duYIz9QzfQo+YQqaonq2pvt/808BCwcZ7StI41lAN7Hhu6heN8ZwL/wk5iT/uHbmCM/UM3\n0KNe34kkmQa2AnfP8/F5SfYmuSXJa/ocV9Jw1vR1oSRrga8BH+ruSEbdC2ypqmeT7AC+AZw17lqv\n4BV9tdWLF/GiievpydM2wMsmqydOe3zielq74XFe/orJ6glg7eOT1defnH02fP/7y/reVFVzA0nW\nADcDt1XVp5ZQ/1PgL6rqqXk+a29I0rJU1Qm/dujrTuTzwI/HBUiS9VV1pNvfxmx4HRcgsLxfhKTh\nNIdIkvOB9wAPJrkfKOCjwBRQVXUdcFGSS4FjwK+Ad7SOK2ky9PI4I+n5a9AVq0lekuT2JD9J8m9J\n1o2p25/kh0nuT/JfK9TLhUkeTvJIkivG1FyTZF/3U6atK9HHifa12gv5klyf5EiSBxaoWdV5Wqyn\nIRY7LmURZle32nPV/+LQqhpsAz4J/EO3fwXwiTF1/wO8ZAX7OAV4lNlHsBcAe4Fz5tTsAG7p9l8P\n/GAV5mcpfW0Hdq/i79lfMvtj/AfGfD7EPC3W06rOUTfmBmBrt78W+MmE/JlaSl8nNF9D/9uZncAN\n3f4NwNvH1IWVvWvaBuyrqgNVdQz4ctfbqJ3AjQBVdTewLsn6FexpqX3BKi7kq6q7gF8sULLq87SE\nnmCVFzvW0hZhDjFXvS8OHTpEzqjupzZV9SRwxpi6Au5Ick+SD6xAHxuBgyPHhzh+YufWHJ6nZoi+\nYLIW8g0xT0sx2BwtsAhz0Lnqa3Fob4vNxklyBzCarmE2FOZ7zhr3lvf8qnoiycuYDZOHuv/66AQX\n8j1PDTZHiyzCHEyfi0NX/E6kqt5YVX82sv1p93U3cOS527ckG4CfjbnGE93XnwNfZ/Y2v0+HgS0j\nx5u6c3NrNi9S07dF+6qqp6vq2W7/NuAFSU5f4b4WMsQ8LWioOeoWYX4N+GJV3TRPySBztVhfJzpf\nQz/O7Abe3+2/DzjuF5TktC41SfJC4E3Af/fcxz3Aq5JMJTkVeGfX29xe39v1cS5w9LlHsRW0aF+j\nz9CLLeTrURj/zDzEPC3Y00BzBIsswmS4uVp0cejI/uLztZpvrOd5U3w68G1m3xDfDvxxd/7lwM3d\n/iuZ/anE/cCDwEdWqJcLuz72PTcGcAnwdyM1n2b2pyU/BF63SnO0YF/AZcyG6v3AfwKvX+F+vgQ8\nDvwv8Bhw8dDztFhPqz1H3ZjnA78Z+bN7X/d7OfRcLdrXic6Xi80kNRn6cUbSSc4QkdTEEJHUxBCR\n1MQQkdTEEJHUxBCR1MQQkdTk/wDRMuj4i5AJ/wAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAREAAAEACAYAAACUHkKwAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAADtRJREFUeJzt3X2MXmWZx/HvDysmBkXApawUZoiCrFKCkiDqsp0NawSz\nsRujiy+JoJtgjCwm/rEYlixgNqv418qKMUQ0oCFdZROo77iy48uqyEJrW6FQE1qgQEksxEWMW8m1\nf8wBH2ee6UznPjPPU/l+kpO5n3OuOffVM+kv55y5m6aqkKSlOmTUDUg6uBkikpoYIpKaGCKSmhgi\nkpoYIpKaNIVIkiOS3Jrk3iTfTnL4PHVPJ7kryaYkN7fMKWm8pGWdSJKrgF9W1SeTXAIcUVUfHVL3\nq6p6cUOfksZUa4hsB9ZV1Z4kxwDTVXXykLr/raoXNfQpaUy1vhM5uqr2AFTVo8DR89S9IMlPk/wo\nyfrGOSWNkVULFST5DrB6cBdQwGVDyue7rZmoqkeSnADclmRLVd1/wN1KGjsLhkhVvWm+Y0n2JFk9\n8Djz2DzneKT7en+SaeA1wJwQSeI/5JFGqKpyoN+zYIgsYCNwAXAVcD5wy+yCJC8Bnqqq/0vyUuAN\nXf08Lm9saTlMA1Mj7mGWdQV/ecWou/hD/3XF2PV0Vv0F6644a9Rt/IHvXfGDsetpLadyXt61pO9t\nfSdyFfCmJPcCZwOfAEhyepJru5o/A/4nySbgu8DHq2p747ySxkTTnUhV7QX+asj+O4ELu/GPgVNb\n5pE0vlyxuiiTo25grsmpUXcw1xj2NDF1/KhbmGMce2phiCzK5KgbmOuEqVF3MNcY9jQ5NTHqFuYY\nx55aGCKSmhgikpoYIpKaGCKSmhgikpoYIpKaGCKSmhgikpoYIpKaGCKSmhgikpoYIpKaGCKSmhgi\nkpoYIpKaGCKSmhgikpoYIpKaGCKSmhgikpoYIpKaGCKSmhgikpoYIpKaGCKSmhgikpr0EiJJzkmy\nPcl9SS4ZcvzQJBuS7Ejy4yR/XP8ZqfQc1hwiSQ4BPg28GXg18K4kJ88q+ztgb1WdCPwr8MnWeSWN\nhz7uRM4AdlTVrqraB2wA1s+qWQ9c341vAs7uYV5JY6CPEDkWeHDg80PdvqE1VfU08ESSI3uYW9KI\njerFakY0r6SererhHLuBwRela7p9gx4CjgMeTvI84MVVtXf46aYHxpPdJqlvO6d3sWv6AQC2c9+S\nz9NHiNwBvCLJBPAI8E7gXbNqvgqcD9wOvAO4bf7TTfXQkqSFTE5NMDk1AcBaTuWmK/9jSedpDpGq\nejrJRcCtzDweXVdV9yS5Erijqr4GXAd8MckO4JfMBI2kPwJ93IlQVd8CXjlr3+UD498Cf9vHXJLG\niytWJTUxRCQ1MUQkNTFEJDUxRCQ1MUQkNTFEJDUxRCQ1MUQkNTFEJDUxRCQ1MUQkNTFEJDUxRCQ1\nMUQkNTFEJDUxRCQ1MUQkNTFEJDUxRCQ1MUQkNTFEJDUxRCQ1MUQkNTFEJDUxRCQ1MUQkNTFEJDUx\nRCQ16SVEkpyTZHuS+5JcMuT4+UkeS3JXt72/j3kljd6q1hMkOQT4NHA28DBwR5Jbqmr7rNINVXVx\n63ySxksfdyJnADuqaldV7QM2AOuH1KWHuSSNmT5C5FjgwYHPD3X7Zntbks1JvpxkTQ/zShoDzY8z\ni7QRuLGq9iW5ELiemcefudbV78eT62ByagXaO/hc9k//OOoWDgofu+bjo25hbE3fB9M7ZsY/P+qU\nJZ+njxDZDRw/8HlNt+9ZVfX4wMfPAZ+c92xTl/fQkqSFTJ00swFw4lo+9qVtSzpPH48zdwCvSDKR\n5FDgnczceTwryTEDH9cDd/cwr6Qx0HwnUlVPJ7kIuJWZULququ5JciVwR1V9Dbg4yVuBfcBe4ILW\neSWNh17eiVTVt4BXztp3+cD4UuDSPuaSNF5csSqpiSEiqYkhIqmJISKpiSEiqYkhIqmJISKpiSEi\nqYkhIqmJISKpiSEiqYkhIqmJISKpiSEiqYkhIqmJISKpiSEiqYkhIqmJISKpiSEiqYkhIqmJISKp\niSEiqYkhIqmJISKpiSEiqYkhIqmJISKpSS8hkuS6JHuSbNlPzdVJdiTZnOS0PuaVNHp93Yl8AXjz\nfAeTnAu8vKpOBD4AfLaneSWNWC8hUlU/BB7fT8l64Iau9nbg8CSr+5hb0mit1DuRY4EHBz7v7vZJ\nOsitGnUDc0xf+fvx5DqYnBpZK9Ifs+n7YHpH9+GorUs+z0qFyG7guIHPa7p9c01dvhL9SM95UyfN\nbACcuJaPfWnbks7T5+NMum2YjcB7AZKcCTxRVXt6nFvSiPRyJ5LkRmAKOCrJA8DlwKFAVdW1VfWN\nJG9J8gvg18D7+phX0uj1EiJV9e5F1FzUx1ySxosrViU1MUQkNTFEJDUxRCQ1MUQkNTFEJDUxRCQ1\nMUQkNTFEJDUxRCQ1MUQkNTFEJDUxRCQ1MUQkNTFEJDUxRCQ1MUQkNTFEJDUxRCQ1MUQkNTFEJDUx\nRCQ1MUQkNTFEJDUxRCQ1MUQkNTFEJDUxRCQ16SVEklyXZE+SLfMcX5fkiSR3ddtlfcwrafRW9XSe\nLwD/Btywn5rvV9Vbe5pP0pjo5U6kqn4IPL5AWfqYS9J4Wcl3Imcm2ZTk60letYLzSlpGfT3OLORO\nYKKqnkpyLnAzcNKwwrNq3bPjianjmZyaWJkODzJXXvPxUbdwULjy70fdwfja2W0AR5+ydcnnWZEQ\nqaonB8bfTPKZJEdW1d7ZteuuOGslWpKe8ya7DeCUtWv5yrZtSzpPn48zYZ73HklWD4zPADIsQCQd\nfHq5E0lyIzAFHJXkAeBy4FCgqupa4O1JPgjsA34DnNfHvJJGr5cQqap3L3D8GuCaPuaSNF5csSqp\niSEiqYkhIqmJISKpiSEiqYkhIqmJISKpiSEiqYkhIqmJISKpiSEiqYkhIqmJISKpiSEiqYkhIqmJ\nISKpiSEiqYkhIqmJISKpiSEiqYkhIqmJISKpiSEiqYkhIqmJISKpiSEiqYkhIqmJISKpSXOIJFmT\n5LYkP0+yNcnF89RdnWRHks1JTmudV9J4WNXDOX4HfKSqNic5DLgzya1Vtf2ZgiTnAi+vqhOTvA74\nLHBmD3NLGrHmO5GqerSqNnfjJ4F7gGNnla0HbuhqbgcOT7K6dW5Jo9frO5Ekk8BpwO2zDh0LPDjw\neTdzg0bSQai3EOkeZW4CPtzdkUh6DujjnQhJVjETIF+sqluGlOwGjhv4vKbbN8f3rvjBs+OJqeOZ\nnJroo0VJs+zsNoC7t25d8nl6CRHg88DdVfWpeY5vBD4E/HuSM4EnqmrPsMJ1V5zVU0uS9mey2wBO\nWbuWr2zbtqTzNIdIkjcC7wG2JtkEFHApMAFUVV1bVd9I8pYkvwB+DbyvdV5J46E5RKrqv4HnLaLu\nota5JI0fV6xKamKISGpiiEhqYohIamKISGpiiEhqYohIamKISGpiiEhqYohIamKISGpiiEhqYohI\namKISGpiiEhqYohIamKISGpiiEhqYohIamKISGpiiEhqYohIamKISGpiiEhqYohIamKISGpiiEhq\nYohIatIcIknWJLktyc+TbE1y8ZCadUmeSHJXt13WOq+k8dDHncjvgI9U1auB1wMfSnLykLrvV9Vr\nu+2fe5h3xeyc3jXqFuaY3jHqDuYax552jrqBIXaOuoGeNYdIVT1aVZu78ZPAPcCxQ0rTOteo7Jp+\nYNQtzPG9MfwLO4497Rx1A0PsHHUDPev1nUiSSeA04PYhh89MsinJ15O8qs95JY3Oqr5OlOQw4Cbg\nw90dyaA7gYmqeirJucDNwEnDzvMyXtZXS715ES8au74efeEx8Cfj1RMvfHjsejrsmIf505eNWU8P\nj19PR5xwwpK/N1XV3ECSVcDXgG9W1acWUX8/cHpV7Z21v70ZSUtWVQf82qGvO5HPA3fPFyBJVlfV\nnm58BjPhtXd23VL+AJJGqzlEkrwReA+wNckmoIBLgQmgqupa4O1JPgjsA34DnNc6r6Tx0MvjjKTn\nrpGuWE1yRJJbk9yb5NtJDp+n7ulukdqmJDcvUy/nJNme5L4klww5fmiSDUl2JPlxkuOXo48l9HV+\nkscGFvK9f5n7uS7JniRb9lNzdXedNic5bTn7WUxPo1jsuJhFmF3dil2rZVsYWlUj24CrgH/oxpcA\nn5in7lfL3MchwC+YeQR7PrAZOHlWzQeBz3Tj84ANK3B9FtPX+cDVK/gz+3Nmfo2/ZZ7j5wJf78av\nA34yBj2tAzau1DXq5jwGOK0bHwbcO+Rnt6LXapE9HfC1GvW/nVkPXN+Nrwf+Zp665X7hegawo6p2\nVdU+YEPX26DBXm8Czl7mnhbbF6zgQr6q+iHw+H5K1gM3dLW3A4cnWT3inmCFFzvW4hZhrui1WmRP\ncIDXatQhcnR1v7WpqkeBo+epe0GSnyb5UZJhf4laHQs8OPD5IeZe3Gdrqupp4IkkRy5DLwfaF8Db\nutvhLydZs8w9LWR2z7sZ3vNKG9lix/0swhzZtepzYWhvi83mk+Q7wGC6hpnf4Ax71prvLe9EVT2S\n5ATgtiRbqur+nls9UOPy6+iNwI1VtS/JhczcLa3EXdLBZNGLHfu2wCLMkehrYegzlv1OpKreVFWn\nDmxru68bgT3P3L4lOQZ4bJ5zPNJ9vR+YBl7Tc5u7gcEXpWu6fYMeAo7ren0e8OIastZlpfuqqse7\nRx2AzwGnL3NPC9lNd506w67liqqqJ6vqqW78TeD5K3AX+cwizJuAL1bVLUNKVvxaLdTTUq7VqB9n\nNgIXdOPzgTl/qCQvSXJoN34p8Abg7p77uAN4RZKJbq53dr0N+mrXI8A7gNt67mFJfXXh+4z19H9t\nhgnz34ltBN4LkORM4IlnHllH1dPge4b9LXZcBvtdhMlortWCC0MHxou7Viv5xnrI2+Ijgf9k5i3x\nrcBLuv2nA9d249cDW4BNwM+AC5apl3O6PnYAH+32XQn8dTd+AfDl7vhPgMkVukYL9fUvwLbu+nwX\nOGmZ+7kReBj4LfAA8D7gA8CFAzWfZua3Sj8DXrsC12i/PQEfGrhGPwJetwI9vRF4mpnfqG0C7up+\nliO7VovpaSnXysVmkpqM+nFG0kHOEJHUxBCR1MQQkdTEEJHUxBCR1MQQkdTEEJHU5P8BicLjTxAC\nPVsAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x10c64bc88>"
+       "<matplotlib.figure.Figure at 0x7f2cb564a550>"
       ]
      },
      "metadata": {},
@@ -380,9 +394,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -165,7 +165,8 @@ class IPyNbFile(pytest.File):
     in the notebook for testing.
     yields pytest items that are required by pytest.
     """
-    def __init__(self, *args, compare_outputs=True, **kwargs):
+    def __init__(self, *args, **kwargs):
+        compare_outputs = kwargs.pop('compare_outputs', True)
         super(IPyNbFile, self).__init__(*args, **kwargs)
         self.sanitize_patterns = OrderedDict()  # Filled in setup_sanitize_patterns()
         self.compare_outputs = compare_outputs

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -54,7 +54,11 @@ def pytest_addoption(parser):
     """
     group = parser.getgroup("general")
     group.addoption('--nbval', action='store_true',
-                    help="Validate IPython notebooks")
+                    help="Validate Jupyter notebooks")
+
+    group.addoption('--nbval-lax', action='store_true',
+                    help="Run Jupyter notebooks, only validating output on "
+                         "cells marked with # NBVAL_CHECK_OUTPUT")
 
     group.addoption('--sanitize-with',
                     help='File with regex expressions to sanitize '
@@ -66,9 +70,11 @@ def pytest_collect_file(path, parent):
     """
     Collect IPython notebooks using the specified pytest hook
     """
-    if path.fnmatch("*.ipynb") and parent.config.option.nbval:
-        return IPyNbFile(path, parent)
-
+    if path.fnmatch("*.ipynb"):
+        if parent.config.option.nbval:
+            return IPyNbFile(path, parent)
+        elif parent.config.option.nbval_lax:
+            return IPyNbFile(path, parent, compare_outputs=False)
 
 
 class RunningKernel(object):


### PR DESCRIPTION
* Added `NBVAL_IGNORE_OUTPUT` as a synonym for `PYTEST_VALIDATE_IGNORE_OUTPUT` (#16)
* Added `--nbval-lax` (I'd love to find a better name for this - any ideas?) to run notebooks and check for errors but not compare outputs by default. (#18)
* A new marker comment `# NBVAL_CHECK_OUTPUT` asks it to compare outputs of specific cells when running with `--nbval-lax`.
* Detect marker comments on any line in the cell, and made comment checking more flexible.