### PR TITLE
Add cell metadata config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .ipynb_checkpoints/
 /dist/
 *.egg-info
+.cache

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -591,9 +591,6 @@ class IPyNbCell(pytest.Item):
 
     def sanitize(self, s):
         """sanitize a string for comparison.
-
-        fix universal newlines, strip trailing newlines,
-        and normalize likely random values (memory addresses and UUIDs)
         """
         if not isinstance(s, six.string_types):
             return s

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -259,6 +259,11 @@ class IPyNbCell(pytest.Item):
         self.metadata = metadata
         self.docompare = docompare
 
+        extra_sanitizers = self.metadata.get('extra_sanitizers', '')
+        self.sanitize_patterns = OrderedDict(
+            get_sanitize_patterns(extra_sanitizers))
+
+
     """ *****************************************************
         *****************  TESTING FUNCTIONS  ***************
         ***************************************************** """
@@ -613,9 +618,7 @@ class IPyNbCell(pytest.Item):
         for pattern in six.iteritems(self.parent.sanitize_patterns):
             yield pattern
         # Also include cell-specific regex
-        own_raw = self.metadata.get('extra_sanitizers', '')
-        own_patterns = OrderedDict(get_sanitize_patterns(own_raw))
-        for pattern in six.iteritems(own_patterns):
+        for pattern in six.iteritems(self.sanitize_patterns):
             yield pattern
 
 

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -235,8 +235,11 @@ class IPyNbFile(pytest.File):
                 else:
                     compare_outputs = (comment_indication == 'check')
 
+                metadata = cell.metadata.get('nbval', {})
+
                 yield IPyNbCell('Cell ' + str(cell_num), self, cell_num,
-                                cell, docompare=compare_outputs)
+                                cell, metadata=metadata,
+                                docompare=compare_outputs)
 
             # Update 'code' cell count
             cell_num += 1
@@ -246,7 +249,7 @@ class IPyNbFile(pytest.File):
 
 
 class IPyNbCell(pytest.Item):
-    def __init__(self, name, parent, cell_num, cell, docompare=True):
+    def __init__(self, name, parent, cell_num, cell, metadata, docompare):
         super(IPyNbCell, self).__init__(name, parent)
 
         # Store reference to parent IPynbFile so that we have access
@@ -254,7 +257,8 @@ class IPyNbCell(pytest.Item):
         self.parent = parent
         self.cell_num = cell_num
         self.cell = cell
-        self.docompare = docompare
+        self.metadata = metadata
+        self.docompare = metadata.get('compare_outputs', docompare)
 
     """ *****************************************************
         *****************  TESTING FUNCTIONS  ***************

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -226,16 +226,15 @@ class IPyNbFile(pytest.File):
             # Skip the cells that have text, headings or related stuff
             # Only test code cells
             if cell.cell_type == 'code':
+                metadata = cell.metadata.get('nbval', {})
                 # The cell may contain a comment indicating that its output
                 # should be checked or ignored. If it doesn't, use the default
                 # behaviour. The --nbval option checks unmarked cells.
                 comment_indication = find_comment_marker(cell.source)
                 if comment_indication is None:
-                    compare_outputs = self.compare_outputs
+                    compare_outputs = metadata.get('compare_outputs', self.compare_outputs)
                 else:
                     compare_outputs = (comment_indication == 'check')
-
-                metadata = cell.metadata.get('nbval', {})
 
                 yield IPyNbCell('Cell ' + str(cell_num), self, cell_num,
                                 cell, metadata=metadata,
@@ -258,7 +257,7 @@ class IPyNbCell(pytest.Item):
         self.cell_num = cell_num
         self.cell = cell
         self.metadata = metadata
-        self.docompare = metadata.get('compare_outputs', docompare)
+        self.docompare = docompare
 
     """ *****************************************************
         *****************  TESTING FUNCTIONS  ***************

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -522,7 +522,7 @@ class IPyNbCell(pytest.Item):
             # 'execution_count' number which does not seems useful
             # (we will filter it in the sanitize function)
             #
-            # When the reply is display_data or execute_count,
+            # When the reply is display_data or execute_result,
             # the dictionary contains
             # a 'data' sub-dictionary with the 'text' AND the 'image/png'
             # picture (in hexadecimal). There is also a 'metadata' entry

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -614,13 +614,12 @@ class IPyNbCell(pytest.Item):
         return s
 
     def _get_santitize_patterns(self):
-        # Yield patterns from parent
-        for pattern in six.iteritems(self.parent.sanitize_patterns):
-            yield pattern
-        # Also include cell-specific regex
+        # Yield cell-specific patterns first
         for pattern in six.iteritems(self.sanitize_patterns):
             yield pattern
-
+        # Then yield patterns from parent
+        for pattern in six.iteritems(self.parent.sanitize_patterns):
+            yield pattern
 
 
 def get_sanitize_patterns(string):

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -605,9 +605,20 @@ class IPyNbCell(pytest.Item):
         is passed when py.test is called. Otherwise, the strings
         are not processed
         """
-        for regex, replace in six.iteritems(self.parent.sanitize_patterns):
+        for regex, replace in self._get_santitize_patterns():
             s = re.sub(regex, replace, s)
         return s
+
+    def _get_santitize_patterns(self):
+        # Yield patterns from parent
+        for pattern in six.iteritems(self.parent.sanitize_patterns):
+            yield pattern
+        # Also include cell-specific regex
+        own_raw = self.metadata.get('extra_sanitizers', '')
+        own_patterns = OrderedDict(get_sanitize_patterns(own_raw))
+        for pattern in six.iteritems(own_patterns):
+            yield pattern
+
 
 
 def get_sanitize_patterns(string):

--- a/tests/sample_notebook.ipynb
+++ b/tests/sample_notebook.ipynb
@@ -45,6 +45,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Different ways to ignore output differences."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
@@ -65,6 +72,76 @@
    "source": [
     "# PYTEST_VALIDATE_IGNORE_OUTPUT\n",
     "datetime.now()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2017, 1, 3, 16, 6, 20, 529355)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "datetime.now()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "nbval": {
+     "compare_outputs": false
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2017, 1, 3, 16, 6, 20, 543350)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datetime.now()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "nbval": {
+     "compare_outputs": true
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(5)"
    ]
   },
   {

--- a/tests/sample_notebook.ipynb
+++ b/tests/sample_notebook.ipynb
@@ -124,6 +124,32 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "nbval": {
+     "compare_outputs": true
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2017, 1, 3, 16, 6, 20, 543350)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "datetime.now()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 6,
    "metadata": {
     "collapsed": false,

--- a/tests/sample_notebook.ipynb
+++ b/tests/sample_notebook.ipynb
@@ -41,7 +41,8 @@
    },
    "outputs": [],
    "source": [
-    "from datetime import datetime"
+    "from datetime import datetime\n",
+    "import numpy as np"
    ]
   },
   {
@@ -171,6 +172,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Test output sanitization"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 31,
    "metadata": {
@@ -191,6 +199,31 @@
    "source": [
     "#datetime.today().strftime(\"%a %y %b %Y, %H:%M:%S\")\n",
     "datetime.today().strftime(\"Last executed: %Y-%m-%d, %H:%M:%S\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false,
+    "nbval": {
+     "extra_sanitizers": "[random float]\nregex: [01]\\.\\d+\nreplace: FLOAT"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text": [
+       "[0.36133679016382714, 0.5043774697891126, 0.23281910875007927, 0.2713065513128683]\n"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "print([np.random.rand() for i in range(4)])\n"
    ]
   },
   {


### PR DESCRIPTION
Implementation suggestion of #5.

Details:
 - Looks for a field `nbval` on the metadata of a cell.
 - Adds boolean subfield `compare_outputs` (priority: comments, metadata, global).
 - Adds string subfield `extra_sanitizers`, for adding cell specific output sanitization. Same format as for sanitization files.

Suggestions for better names for the metadata fields are welcome!