### PR TITLE
Use kernel from `kernelspec` if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ install:
   - pip install .
 
 # command to run tests
-script: py.test tests/ --nbval --sanitize-with tests/sanitize_defaults.cfg
+script: py.test tests/ --nbval --current-env --sanitize-with tests/sanitize_defaults.cfg

--- a/nbval/kernel.py
+++ b/nbval/kernel.py
@@ -1,0 +1,112 @@
+"""
+pytest ipython plugin modification
+
+Authors: D. Cortes, O. Laslett, T. Kluyver, H. Fangohr, V.T. Fauske
+
+"""
+
+import os
+
+# Kernel for jupyter notebooks
+from jupyter_client.manager import KernelManager
+from jupyter_client.kernelspec import KernelSpecManager
+import ipykernel.kernelspec
+
+
+CURRENT_ENV_KERNEL_NAME = ':nbval-parent-env'
+
+
+class NbvalKernelspecManager(KernelSpecManager):
+    """Kernel manager that also allows for python kernel in parent environment
+    """
+
+    def get_kernel_spec(self, kernel_name):
+        """Returns a :class:`KernelSpec` instance for the given kernel_name.
+
+        Raises :exc:`NoSuchKernel` if the given kernel name is not found.
+        """
+        if kernel_name == CURRENT_ENV_KERNEL_NAME:
+            return self.kernel_spec_class(
+                resource_dir=ipykernel.kernelspec.RESOURCES,
+                **ipykernel.kernelspec.get_kernel_dict())
+        else:
+            return super().get_kernel_spec(kernel_name)
+
+
+def start_new_kernel(startup_timeout=60, kernel_name='python', **kwargs):
+    """Start a new kernel, and return its Manager and Client"""
+    km = KernelManager(kernel_name=kernel_name,
+                       kernel_spec_manager=NbvalKernelspecManager())
+    km.start_kernel(**kwargs)
+    kc = km.client()
+    kc.start_channels()
+    try:
+        kc.wait_for_ready(timeout=startup_timeout)
+    except RuntimeError:
+        kc.stop_channels()
+        km.shutdown_kernel()
+        raise
+
+    return km, kc
+
+
+class RunningKernel(object):
+    """
+    Running a Kernel a Jupyter, info can be found at:
+    http://jupyter-client.readthedocs.org/en/latest/messaging.html
+
+    The purpose of this class is to encapsulate interaction with the
+    jupyter kernel. Thus any changes on the jupyter side to how
+    kernels are started/managed should not require any changes outside
+    this class.
+
+    """
+    def __init__(self, kernel_name):
+        """
+        Initialise a new kernel
+        specfiy that matplotlib is inline and connect the stderr.
+        Stores the active kernel process and its manager.
+        """
+
+        self.km, self.kc = start_new_kernel(
+            kernel_name=kernel_name,
+            stderr=open(os.devnull, 'w'))
+
+    def get_message(self, stream, timeout=None):
+        """
+        Function is used to get a message from the iopub channel.
+        Timeout is None by default
+        When timeout is reached
+        """
+        if stream == 'iopub':
+            return self.kc.get_iopub_msg(timeout=timeout)
+        elif stream == 'shell':
+            return self.kc.get_shell_msg(timeout=timeout)
+
+    def execute_cell_input(self, cell_input, allow_stdin=None):
+        """
+        Executes a string of python code in cell input.
+        We do not allow the kernel to make requests to the stdin
+             this is the norm for notebooks
+
+        Function returns a unique message id of the reply from
+        the kernel.
+        """
+        return self.kc.execute(cell_input, allow_stdin=allow_stdin)
+
+    # These options are in case we wanted to restart the nb every time
+    # it is executed a certain task
+    def restart(self):
+        """
+        Instructs the kernel manager to restart the kernel process now.
+        """
+        self.km.restart_kernel(now=True)
+
+    def stop(self):
+        """
+        Instructs the kernel process to stop channels
+        and the kernel manager to then shutdown the process.
+        """
+        self.kc.stop_channels()
+        self.km.shutdown_kernel(now=True)
+        del self.km

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -88,15 +88,16 @@ class RunningKernel(object):
     this class.
 
     """
-    def __init__(self):
+    def __init__(self, kernel_name):
         """
         Initialise a new kernel
         specfiy that matplotlib is inline and connect the stderr.
         Stores the active kernel process and its manager.
         """
-        self.km, self.kc = \
-                start_new_kernel(extra_arguments=['--matplotlib=inline'],
-                                  stderr=open(os.devnull, 'w'))
+
+        self.km, self.kc = start_new_kernel(
+            kernel_name=kernel_name,
+            stderr=open(os.devnull, 'w'))
 
 
     def get_message(self, stream, timeout=None):
@@ -176,7 +177,9 @@ class IPyNbFile(pytest.File):
         Called by pytest to setup the collector cells in .
         Here we start a kernel and setup the sanitize patterns.
         """
-        self.kernel = RunningKernel()
+
+        kernel_name = self.nb.metadata.get('kernelspec', {}).get('name', 'python')
+        self.kernel = RunningKernel(kernel_name)
         self.setup_sanitize_files()
 
 
@@ -216,6 +219,7 @@ class IPyNbFile(pytest.File):
         The collect function is required by pytest and is used to yield pytest
         Item objects. We specify an Item for each code cell in the notebook.
         """
+
         self.nb = nbformat.read(str(self.fspath), as_version=4)
 
         # Start the cell count

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -1,13 +1,12 @@
 """
 pytest ipython plugin modification
 
-Authors: D. Cortes, O. Laslett, T. Kluyver, H. Fangohr
+Authors: D. Cortes, O. Laslett, T. Kluyver, H. Fangohr, V.T. Fauske
 
 """
 
 # import the pytest API
 import pytest
-import os
 import sys
 import re
 from collections import OrderedDict
@@ -15,11 +14,6 @@ from collections import OrderedDict
 # for python 3 compatibility
 PY3 = sys.version_info[0] >= 3
 import six
-
-# Kernel for jupyter notebooks
-from jupyter_client.manager import KernelManager
-from jupyter_client.kernelspec import KernelSpecManager
-import ipykernel.kernelspec
 
 try:
     from Queue import Empty
@@ -30,6 +24,9 @@ except:
 import nbformat
 from nbformat import NotebookNode
 
+# Kernel for running notebooks
+from .kernel import RunningKernel, CURRENT_ENV_KERNEL_NAME
+
 # define colours for pretty outputs
 class bcolors:
     HEADER = '\033[95m'
@@ -38,9 +35,6 @@ class bcolors:
     WARNING = '\033[93m'
     FAIL = '\033[91m'
     ENDC = '\033[0m'
-
-
-CURRENT_ENV_KERNEL_NAME = ':nbval-parent-env'
 
 
 class NbCellError(Exception):
@@ -86,102 +80,6 @@ def pytest_collect_file(path, parent):
         elif parent.config.option.nbval_lax:
             return IPyNbFile(path, parent, compare_outputs=False)
 
-
-class NbvalKernelspecManager(KernelSpecManager):
-    """Kernel manager that also allows for python kernel in parent environment"""
-
-    def get_kernel_spec(self, kernel_name):
-        """Returns a :class:`KernelSpec` instance for the given kernel_name.
-
-        Raises :exc:`NoSuchKernel` if the given kernel name is not found.
-        """
-        if kernel_name == CURRENT_ENV_KERNEL_NAME:
-            return self.kernel_spec_class(
-                resource_dir=ipykernel.kernelspec.RESOURCES,
-                **ipykernel.kernelspec.get_kernel_dict())
-        else:
-            return super().get_kernel_spec(kernel_name)
-
-
-def start_new_kernel(startup_timeout=60, kernel_name='python', **kwargs):
-    """Start a new kernel, and return its Manager and Client"""
-    km = KernelManager(kernel_name=kernel_name,
-                       kernel_spec_manager=NbvalKernelspecManager())
-    km.start_kernel(**kwargs)
-    kc = km.client()
-    kc.start_channels()
-    try:
-        kc.wait_for_ready(timeout=startup_timeout)
-    except RuntimeError:
-        kc.stop_channels()
-        km.shutdown_kernel()
-        raise
-
-    return km, kc
-
-
-class RunningKernel(object):
-    """
-    Running a Kernel a Jupyter, info can be found at:
-    http://jupyter-client.readthedocs.org/en/latest/messaging.html
-
-    The purpose of this class is to encapsulate interaction with the
-    jupyter kernel. Thus any changes on the jupyter side to how
-    kernels are started/managed should not require any changes outside
-    this class.
-
-    """
-    def __init__(self, kernel_name):
-        """
-        Initialise a new kernel
-        specfiy that matplotlib is inline and connect the stderr.
-        Stores the active kernel process and its manager.
-        """
-
-        self.km, self.kc = start_new_kernel(
-            kernel_name=kernel_name,
-            stderr=open(os.devnull, 'w'))
-
-    def get_message(self, stream, timeout=None):
-        """
-        Function is used to get a message from the iopub channel.
-        Timeout is None by default
-        When timeout is reached
-        """
-        if stream == 'iopub':
-            return self.kc.get_iopub_msg(timeout=timeout)
-        elif stream == 'shell':
-            return self.kc.get_shell_msg(timeout=timeout)
-
-    def execute_cell_input(self, cell_input, allow_stdin=None):
-        """
-        Executes a string of python code in cell input.
-        We do not allow the kernel to make requests to the stdin
-             this is the norm for notebooks
-
-        Function returns a unique message id of the reply from
-        the kernel.
-        """
-        return self.kc.execute(cell_input, allow_stdin=allow_stdin)
-
-
-    # These options are in case we wanted to restart the nb every time
-    # it is executed a certain task
-    def restart(self):
-        """
-        Instructs the kernel manager to restart the kernel process now.
-        """
-        self.km.restart_kernel(now=True)
-
-
-    def stop(self):
-        """
-        Instructs the kernel process to stop channels
-        and the kernel manager to then shutdown the process.
-        """
-        self.kc.stop_channels()
-        self.km.shutdown_kernel(now=True)
-        del self.km
 
 
 comment_markers = {


### PR DESCRIPTION
Look at `kernelspec` metadata to find kernel name. Defaults to `python` if not specified.

Resolves #21.

Fixes #20, by simply assuming that `--matplotlib=inline` is not needed (assumes recent versions of ipykernel / matplotlib, is that OK?).