### PR TITLE
Report failures with nbdime

### DIFF
--- a/nbval/nbdime_reporter.py
+++ b/nbval/nbdime_reporter.py
@@ -23,6 +23,7 @@ from nbdime.webapp.nbdiffweb import run_server, browse
 
 from .plugin import IPyNbCell
 
+nbdime.log.set_nbdime_log_level('ERROR')
 
 _re_nbval_nodeid = re.compile('.*\.ipynb::Cell \d+')
 

--- a/nbval/nbdime_reporter.py
+++ b/nbval/nbdime_reporter.py
@@ -1,0 +1,131 @@
+"""
+pytest ipython plugin modification - Nbdime reporter
+
+Authors: V.T. Fauske
+
+"""
+
+# import the pytest API
+import pytest
+from _pytest.main import EXIT_OK, EXIT_TESTSFAILED, EXIT_INTERRUPTED, \
+    EXIT_USAGEERROR, EXIT_NOTESTSCOLLECTED
+
+import re
+import copy
+import tempfile
+import os
+import shutil
+import io
+
+import nbformat
+import nbdime
+from nbdime.webapp.nbdiffweb import run_server, browse
+
+from .plugin import IPyNbCell
+
+
+_re_nbval_nodeid = re.compile('.*\.ipynb::Cell \d+')
+
+
+class NbdimeReporter:
+    def __init__(self, config, file=None):
+        self.config = config
+        self.verbosity = self.config.option.verbose
+        self._numcollected = 0
+
+        self.nbval_items = []
+
+        self.nb_ref = nbformat.v4.new_notebook()
+        self.nb_test = nbformat.v4.new_notebook()
+
+        self.stats = {}
+
+    def pytest_runtest_logreport(self, report):
+        rep = report
+        res = self.config.hook.pytest_report_teststatus(report=rep)
+        cat, letter, word = res
+        self.stats.setdefault(cat, []).append(rep)
+
+    def pytest_collectreport(self, report):
+        """Store all collected tests for evalutation on finish
+        """
+        items = [x for x in report.result if isinstance(x, IPyNbCell)]
+        self.nbval_items.extend(items)
+        self._numcollected += len(items)
+
+
+    # ---- Code below writes up report ----
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_sessionfinish(self, exitstatus):
+        outcome = yield
+        outcome.get_result()
+        summary_exit_codes = (
+            EXIT_OK, EXIT_TESTSFAILED, EXIT_INTERRUPTED, EXIT_USAGEERROR,
+            EXIT_NOTESTSCOLLECTED)
+        if exitstatus in summary_exit_codes:
+            # We had some failures that might need reporting
+            self.make_report(outcome)
+
+    def make_report(self, outcome):
+        failures = self.getreports('failed')
+        if not failures:
+            return
+        for rep in failures:
+            # Check if this is a notebook node
+            msg = self._getfailureheadline(rep)
+            self.section(msg)
+            self._outrep_summary(rep)
+        tmpdir = tempfile.mkdtemp()
+        try:
+            ref_file = os.path.join(tmpdir, 'reference.ipynb')
+            test_file = os.path.join(tmpdir, 'test_result.ipynb')
+            with io.open(ref_file, "w", encoding="utf8") as f:
+                nbformat.write(self.nb_ref, f)
+            with io.open(test_file, "w", encoding="utf8") as f:
+                nbformat.write(self.nb_test, f)
+            run_server(
+                port=0,     # Run on random port
+                cwd=tmpdir,
+                closable=True,
+                on_port=lambda port: browse(
+                    port, ref_file, test_file, None))
+        finally:
+            shutil.rmtree(tmpdir)
+
+    #
+    # summaries for sessionfinish
+    #
+    def getreports(self, name):
+        l = []
+        for x in self.stats.get(name, []):
+            if not hasattr(x, '_pdbshown'):
+                l.append(x)
+        return l
+
+    def section(self, title):
+        # Create markdown cell with title
+        header = nbformat.v4.new_markdown_cell("## " + title)
+        # Add markdown in both ref and test
+        self.nb_ref.cells.append(header)
+        self.nb_test.cells.append(header)
+
+    def _outrep_summary(self, rep):
+        # Find corresponding item
+        for item in self.nbval_items:
+            if item.nodeid == rep.nodeid:
+                # item found, output
+                # Sanitize reference cell
+                ref_cell = item.cell
+                ref_cell.outputs = item.sanitize_outputs(ref_cell.outputs)
+                self.nb_ref.cells.append(item.cell)
+                test_cell = copy.copy(item.cell)
+                test_cell.outputs = item.sanitize_outputs(item.test_outputs)
+                self.nb_test.cells.append(test_cell)
+
+    def _getfailureheadline(self, rep):
+        if hasattr(rep, 'location'):
+            fspath, lineno, domain = rep.location
+            return fspath + '::' + domain
+        else:
+            return "test session"  # XXX?

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -78,7 +78,6 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    config.option.verbose -= config.option.quiet
     if config.option.nbdime:
         from .nbdime_reporter import NbdimeReporter
         reporter = NbdimeReporter(config, sys.stdout)

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -564,7 +564,7 @@ class IPyNbCell(pytest.Item):
             # The traceback containing the difference in the outputs is
             # stored in the variable comparison_traceback
             raise NbCellError(self.cell_num,
-                              "Error with cell",
+                              "Cell outputs differ",
                               self.cell.source,
                               # Here we must put the traceback output:
                               '\n'.join(self.comparison_traceback))

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -27,6 +27,7 @@ from nbformat import NotebookNode
 # Kernel for running notebooks
 from .kernel import RunningKernel, CURRENT_ENV_KERNEL_NAME
 
+
 # define colours for pretty outputs
 class bcolors:
     HEADER = '\033[95m'
@@ -68,6 +69,19 @@ def pytest_addoption(parser):
                     help='Force test execution to use a python kernel in '
                          'the same enviornment that py.test was '
                          'launched from.')
+						 
+    term_group = parser.getgroup("terminal reporting")
+    term_group._addoption(
+        '--nbdime', action='store_true',
+        help="view failed nbval cells with nbdime.")
+
+
+def pytest_configure(config):
+    config.option.verbose -= config.option.quiet
+    if config.option.nbdime:
+        from .nbdime_reporter import NbdimeReporter
+        reporter = NbdimeReporter(config, sys.stdout)
+        config.pluginmanager.register(reporter, 'nbdimereporter')
 
 
 def pytest_collect_file(path, parent):

--- a/tests/sanitize_defaults.cfg
+++ b/tests/sanitize_defaults.cfg
@@ -12,5 +12,5 @@ regex: \d\d:\d\d
 replace: TIMESTAMP
 
 [Memory addresses]
-regex: 0x[0-9a-fA-F]+
-replace: MEMORY_ADDRESS
+regex: (<[a-zA-Z_][0-9a-zA-Z_.]* at )(0x[0-9a-fA-F]+)(>)
+replace: \1MEMORY_ADDRESS\3


### PR DESCRIPTION
Partially resolves #15.

Adds a flag `--nbdime` for pytest, which will report nbval failures using [nbdime](https://github.com/jupyter/nbdime).

Also improves terminal reporting by snipping long base64 strings, and some other minor adjustments (see commit log).