### PR TITLE
Add make target for uploading release to PyPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,12 @@
+PYTHON ?= python3
+
 test:
 	py.test tests/ --nbval --current-env --sanitize-with tests/sanitize_defaults.cfg --ignore tests/ipynb-test-samples
+
+build-dists:
+	rm -rf dist/
+	$(PYTHON) setup.py sdist
+	$(PYTHON) setup.py bdist_wheel
+
+release: build-dists
+	twine upload dist/*


### PR DESCRIPTION
After setting the new version number and testing the code, run 'make release' to push it to PyPI.