### PR TITLE
Various fixes nbdime/Windows

### DIFF
--- a/nbval/nbdime_reporter.py
+++ b/nbval/nbdime_reporter.py
@@ -85,7 +85,9 @@ class NbdimeReporter:
         for rep in failures:
             # Check if this is a notebook node
             msg = self._getfailureheadline(rep)
-            self.section(msg, rep.longrepr.splitlines()[1])
+            lines = rep.longrepr.splitlines()
+            if len(lines) > 1:
+                self.section(msg, lines[1])
             self._outrep_summary(rep)
         tmpdir = tempfile.mkdtemp()
         try:

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -43,6 +43,10 @@ class NbCellError(Exception):
     """ custom exception for error reporting. """
 
 
+class TestTimeoutError(Exception):
+    """ custom exception for error reporting. """
+
+
 def pytest_addoption(parser):
     """
     Adds the --nbval option flag for py.test.
@@ -247,6 +251,8 @@ class IPyNbCell(pytest.Item):
                     bcolors.OKBLUE + "Traceback:%s" + bcolors.ENDC
             msg_items.append(formatstring % excinfo.value.args)
             return "\n".join(msg_items)
+        elif isinstance(excinfo.value, TestTimeoutError):
+            return "%s%s%s" % (bcolors.FAIL, str(excinfo.value), bcolors.ENDC)
         else:
             return "pytest plugin exception: %s" % str(excinfo.value)
 
@@ -406,9 +412,9 @@ class IPyNbCell(pytest.Item):
                 msg = self.parent.get_kernel_message(stream='shell',
                                                      timeout=timeout)
             except Empty:
-                raise NbCellError("Timeout of %d seconds exceeded"
-                                  " executing cell: %s" (timeout,
-                                                         self.cell.input))
+                raise TestTimeoutError(
+                    "Timeout of %d seconds exceeded executing cell: %s" (
+                        timeout, self.cell.input))
 
             # Is this the message we are waiting for?
             if msg['parent_header'].get('msg_id') == msg_id:
@@ -434,8 +440,8 @@ class IPyNbCell(pytest.Item):
             except Empty:
                 # This is not working: ! The code will not be checked
                 # if the time is out (when the cell stops to be executed?)
-                raise NbCellError("Timeout of %d seconds exceeded"
-                                  " waiting for output.")
+                raise TestTimeoutError(
+                    "Timeout of %d seconds exceeded waiting for output.")
 
 
 

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -41,10 +41,11 @@ class bcolors:
 
 class NbCellError(Exception):
     """ custom exception for error reporting. """
-
-
-class TestTimeoutError(Exception):
-    """ custom exception for error reporting. """
+    def __init__(self, cell_num, msg, source, traceback=None, *args, **kwargs):
+        self.cell_num = cell_num
+        super(NbCellError, self).__init__(msg, *args, **kwargs)
+        self.source = source
+        self.inner_traceback = traceback
 
 
 def pytest_addoption(parser):
@@ -244,17 +245,25 @@ class IPyNbCell(pytest.Item):
 
     def repr_failure(self, excinfo):
         """ called when self.runtest() raises an exception. """
-        if isinstance(excinfo.value, NbCellError):
-            msg_items = [bcolors.FAIL + "Notebook cell execution failed" + bcolors.ENDC]
-            formatstring = bcolors.OKBLUE + "Cell %d: %s\n\n" + \
-                    "Input:\n" + bcolors.ENDC + "%s\n\n" + \
-                    bcolors.OKBLUE + "Traceback:%s" + bcolors.ENDC
-            msg_items.append(formatstring % excinfo.value.args)
+        exc = excinfo.value
+        if isinstance(exc, NbCellError):
+            msg_items = [
+                bcolors.FAIL + "Notebook cell execution failed" + bcolors.ENDC]
+            formatstring = (
+                bcolors.OKBLUE + "Cell %d: %s\n\n" +
+                "Input:\n" + bcolors.ENDC + "%s\n")
+            msg_items.append(formatstring % (
+                exc.cell_num,
+                str(exc),
+                exc.source
+                ))
+            if exc.inner_traceback:
+                msg_items.append((
+                    bcolors.OKBLUE + "Traceback:%s" + bcolors.ENDC) %
+                    exc.inner_traceback)
             return "\n".join(msg_items)
-        elif isinstance(excinfo.value, TestTimeoutError):
-            return "%s%s%s" % (bcolors.FAIL, str(excinfo.value), bcolors.ENDC)
         else:
-            return "pytest plugin exception: %s" % str(excinfo.value)
+            return "pytest plugin exception: %s" % str(exc)
 
     def reportinfo(self):
         description = "cell %d" % self.cell_num
@@ -351,10 +360,11 @@ class IPyNbCell(pytest.Item):
 
             # Check if they have the same keys
             if key not in testing_outs.keys():
-                self.comparison_traceback.append(bcolors.FAIL
-                                        + "missing key: TESTING %s != REFERENCE %s"
-                                        % (testing_outs.keys(), reference_outs.keys())
-                                        + bcolors.ENDC)
+                self.comparison_traceback.append(
+                    bcolors.FAIL
+                    + "missing key: TESTING %s != REFERENCE %s"
+                    % (testing_outs.keys(), reference_outs.keys())
+                    + bcolors.ENDC)
                 return False
 
             # Compare the large string from the corresponding dictionary entry
@@ -365,19 +375,22 @@ class IPyNbCell(pytest.Item):
                 # print testing_outs[key]
                 # print reference_outs[key]
 
-                self.comparison_traceback.append(bcolors.OKBLUE
-                                        + " mismatch '%s'\n" % key
-                                        + bcolors.FAIL
-                                        + "<<<<<<<<<<<< Reference output from ipynb file:"
-                                        + bcolors.ENDC)
+                self.comparison_traceback.append(
+                    bcolors.OKBLUE
+                    + " mismatch '%s'\n" % key
+                    + bcolors.FAIL
+                    + "<<<<<<<<<<<< Reference output from ipynb file:"
+                    + bcolors.ENDC)
                 self.comparison_traceback.append(_trim_base64(reference_outs[key]))
-                self.comparison_traceback.append(bcolors.FAIL
-                                        + '============ disagrees with newly computed (test) output:  '
-                                        + bcolors.ENDC)
+                self.comparison_traceback.append(
+                    bcolors.FAIL
+                    + '============ disagrees with newly computed (test) output:  '
+                    + bcolors.ENDC)
                 self.comparison_traceback.append(_trim_base64(testing_outs[str(key)]))
-                self.comparison_traceback.append(bcolors.FAIL
-                                        + '>>>>>>>>>>>>'
-                                        + bcolors.ENDC)
+                self.comparison_traceback.append(
+                    bcolors.FAIL
+                    + '>>>>>>>>>>>>'
+                    + bcolors.ENDC)
 
                 return False
         return True
@@ -404,7 +417,7 @@ class IPyNbCell(pytest.Item):
         # Timeout for the cell execution
         # after code is sent for execution, the kernel sends a message on
         # the shell channel. Timeout if no message received.
-        timeout = 2000
+        timeout = self.options.get('timeout', 20)
 
         # Poll the shell channel to get a message
         while True:
@@ -412,9 +425,10 @@ class IPyNbCell(pytest.Item):
                 msg = self.parent.get_kernel_message(stream='shell',
                                                      timeout=timeout)
             except Empty:
-                raise TestTimeoutError(
-                    "Timeout of %d seconds exceeded executing cell: %s" (
-                        timeout, self.cell.input))
+                raise NbCellError(
+                    self.cell_num,
+                    "Timeout of %d seconds exceeded executing cell" % timeout,
+                    self.cell.source)
 
             # Is this the message we are waiting for?
             if msg['parent_header'].get('msg_id') == msg_id:
@@ -440,8 +454,10 @@ class IPyNbCell(pytest.Item):
             except Empty:
                 # This is not working: ! The code will not be checked
                 # if the time is out (when the cell stops to be executed?)
-                raise TestTimeoutError(
-                    "Timeout of %d seconds exceeded waiting for output.")
+                raise NbCellError(
+                    self.cell_num,
+                    "Timeout of %d seconds exceeded waiting for output." % timeout,
+                    self.cell.source)
 
 
 

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -538,7 +538,7 @@ class IPyNbCell(pytest.Item):
                 # Store error in output first
                 out['ename'] = reply['ename']
                 out['evalue'] = reply['evalue']
-                # out['traceback'] = reply['traceback']
+                out['traceback'] = reply['traceback']
                 outs.append(out)
                 if not self.options['check_exception']:
                     traceback = '\n' + '\n'.join(reply['traceback'])

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -158,8 +158,6 @@ class IPyNbFile(pytest.File):
         else:
             kernel_name = self.nb.metadata.get(
                 'kernelspec', {}).get('name', 'python')
-        with open('testkernel', 'w') as f:
-            f.write(kernel_name)
         self.kernel = RunningKernel(kernel_name)
         self.setup_sanitize_files()
 

--- a/tests/test_unit_tests_in_notebooks.py
+++ b/tests/test_unit_tests_in_notebooks.py
@@ -58,7 +58,10 @@ def test_print(filename, correctoutcome):
           .format(filename, correctoutcome))
     print("Command about to execute is '{}'".format(command))
 
-    exitcode = subprocess.call(command)
+    if os.name == 'nt':
+        exitcode = subprocess.call(command, shell=True)
+    else:
+        exitcode = subprocess.call(command)
 
     if correctoutcome is 'pass':
         assert exitcode is 0


### PR DESCRIPTION
 - `repr_failure` made some assumptions about how `NbCellError`s were initialized. Added different error type for errors that did not comply with this assumption. Is there a good way to add a test for this in test suit? I.e. how to expect py.test to not have an internal error when it has various test failures? 😕 
 - On windows, `subprocess.call()` needs `shell=True` to find `py.test` command. This was an issue in the test suite.
 - Nbdime needs outputs to validate against nbformat schema, so I uncommented a line that was commented out in #35. @wence- : Will it break anything to add this line back?