### PR TITLE
Interrupt kernel on timeout

### DIFF
--- a/nbval/kernel.py
+++ b/nbval/kernel.py
@@ -102,6 +102,13 @@ class RunningKernel(object):
         """
         self.km.restart_kernel(now=True)
 
+    def interrupt(self):
+        """
+        Instructs the kernel to stop whatever it is doing, and await
+        further commands.
+        """
+        self.km.interrupt_kernel()
+
     def stop(self):
         """
         Instructs the kernel process to stop channels

--- a/nbval/kernel.py
+++ b/nbval/kernel.py
@@ -94,6 +94,11 @@ class RunningKernel(object):
         """
         return self.kc.execute(cell_input, allow_stdin=allow_stdin)
 
+    def is_alive(self):
+        if hasattr(self, 'km'):
+            return self.km.is_alive()
+        return False
+
     # These options are in case we wanted to restart the nb every time
     # it is executed a certain task
     def restart(self):

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -75,7 +75,7 @@ def pytest_addoption(parser):
                          'the same enviornment that py.test was '
                          'launched from.')
 
-    group.addoption('--cell-timeout', action='store', default=2000,
+    group.addoption('--nbval-cell-timeout', action='store', default=2000,
                     type=float,
                     help='Timeout for cell execution, in seconds.')
 
@@ -447,7 +447,7 @@ class IPyNbCell(pytest.Item):
         # Timeout for the cell execution
         # after code is sent for execution, the kernel sends a message on
         # the shell channel. Timeout if no message received.
-        timeout = self.config.option.cell_timeout
+        timeout = self.config.option.nbval_cell_timeout
 
         # Poll the shell channel to get a message
         while True:

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -76,7 +76,7 @@ def pytest_addoption(parser):
                          'launched from.')
 
     group.addoption('--cell-timeout', action='store', default=2000,
-                    type='float',
+                    type=float,
                     help='Timeout for cell execution, in seconds.')
 
     term_group = parser.getgroup("terminal reporting")

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -13,7 +13,6 @@ import hashlib
 from collections import OrderedDict, defaultdict
 
 # for python 3 compatibility
-PY3 = sys.version_info[0] >= 3
 import six
 
 try:
@@ -105,6 +104,7 @@ comment_markers = {
     'NBVAL_RAISES_EXCEPTION': 'check_exception',
 }
 
+
 def find_comment_markers(cellsource):
     """Look through the cell source for comments which affect nbval's behaviour
 
@@ -140,8 +140,8 @@ class IPyNbFile(pytest.File):
             'stdout',
             'stream',
             'name',
-            'execution_count'
-            )
+            'execution_count',
+        )
         if not config.option.nbdime:
             self.skip_compare = self.skip_compare + ('image/png', 'image/jpeg')
 
@@ -256,7 +256,7 @@ class IPyNbCell(pytest.Item):
                 exc.cell_num,
                 str(exc),
                 exc.source
-                ))
+            ))
             if exc.inner_traceback:
                 msg_items.append((
                     bcolors.OKBLUE + "Traceback:%s" + bcolors.ENDC) %
@@ -537,7 +537,7 @@ class IPyNbCell(pytest.Item):
                 outs.append(out)
 
                 if msg_type == 'execute_result':
-                     out.execution_count = reply['execution_count']
+                    out.execution_count = reply['execution_count']
 
 
             # if the message is a stream then we store the output
@@ -655,13 +655,15 @@ def get_sanitize_patterns(string):
     A list of (regex, replace) pairs.
     """
     return re.findall('^regex: (.*)$\n^replace: (.*)$',
-                         string,
-                         flags=re.MULTILINE)
+                      string,
+                      flags=re.MULTILINE)
+
 
 def hash_string(s):
     return hashlib.md5(s.encode("utf8")).hexdigest()
 
 _base64 = re.compile(r'^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$', re.MULTILINE | re.UNICODE)
+
 
 def _trim_base64(s):
     """Trim and hash base64 strings"""

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -75,6 +75,10 @@ def pytest_addoption(parser):
                          'the same enviornment that py.test was '
                          'launched from.')
 
+    group.addoption('--cell-timeout', action='store', default=2000,
+                    type='float',
+                    help='Timeout for cell execution, in seconds.')
+
     term_group = parser.getgroup("terminal reporting")
     term_group._addoption(
         '--nbdime', action='store_true',
@@ -417,7 +421,7 @@ class IPyNbCell(pytest.Item):
         # Timeout for the cell execution
         # after code is sent for execution, the kernel sends a message on
         # the shell channel. Timeout if no message received.
-        timeout = self.options.get('timeout', 20)
+        timeout = self.config.option.cell_timeout
 
         # Poll the shell channel to get a message
         while True:

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -124,6 +124,12 @@ def find_comment_markers(cellsource):
                 yield (comment_markers[comment], True)
 
 
+class Dummy:
+    """Needed to use xfail for our tests"""
+    def __init__(self):
+        self.__globals__ = {}
+
+
 class IPyNbFile(pytest.File):
     """
     This class represents a pytest collector object.
@@ -244,6 +250,8 @@ class IPyNbCell(pytest.Item):
         self.test_outputs = None
         self.options = options
         self.config = parent.parent.config
+        # _pytest.skipping assumes all pytest.Item have this attribute:
+        self.obj = Dummy()
 
     """ *****************************************************
         *****************  TESTING FUNCTIONS  ***************

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,14 @@
 [bdist_wheel]
 universal=1
+
+[pep8]
+ignore = E131, E303, W503
+max-line-length = 120
+
+[flake8]
+ignore = E131, E303, W503
+max-line-length = 120
+
+[pycodestyle]
+ignore = E131, E303, W503
+max-line-length = 120

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -6,6 +6,14 @@ import nbformat
 pytest_plugins = "pytester"
 
 
+def _build_nb(sources):
+    """Builds a notebook of only code cells, from a list of sources"""
+    nb = nbformat.v4.new_notebook()
+    for src in sources:
+        nb.cells.append(nbformat.v4.new_code_cell(src))
+    return nb
+
+
 def test_timeouts(testdir):
     # This test uses the testdir fixture from pytester, which is useful for
     # testing pytest plugins. It writes a notebook to a temporary dir
@@ -16,31 +24,15 @@ def test_timeouts(testdir):
     # content of the notebook
 
     # Setup notebook to test:
-    nb = nbformat.v4.new_notebook()
-
-    cell = nbformat.v4.new_code_cell(
-        "from time import sleep")
-    nb.cells.append(cell)
-
-    cell = nbformat.v4.new_code_cell(
-        "for i in range(100000):\n    sleep(1)\nmyvar = 5")
-    nb.cells.append(cell)
-
-    cell = nbformat.v4.new_code_cell(
-        "a = 5")
-    nb.cells.append(cell)
-
-    cell = nbformat.v4.new_code_cell(
-        "print(myvar)")
-    nb.cells.append(cell)
-
-    cell = nbformat.v4.new_code_cell(
-        "for i in range(1000):\n    sleep(100)")
-    nb.cells.append(cell)
-
-    cell = nbformat.v4.new_code_cell(
-        "b = 5")
-    nb.cells.append(cell)
+    sources = [
+        "from time import sleep",
+        "for i in range(100000):\n    sleep(1)\nmyvar = 5",
+        "a = 5",
+        "print(myvar)",
+        "for i in range(1000):\n    sleep(100)",
+        "b = 5",
+    ]
+    nb = _build_nb(sources)
 
     # Write notebook to test dir
     nbformat.write(nb, os.path.join(

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -25,11 +25,22 @@ def test_timeouts(testdir):
 
     # Setup notebook to test:
     sources = [
+        # In [1]:
         "from time import sleep",
-        "for i in range(100000):\n    sleep(1)\nmyvar = 5",
+        # In [2]:
+        "for i in range(100000):\n" +
+        "    sleep(1)\n" +
+        "myvar = 5",
+        # In [3]:
         "a = 5",
+        # In [4]:
         "print(myvar)",
-        "for i in range(1000):\n    sleep(100)",
+        # In [5]:
+        "import signal\n" +
+        "signal.signal(signal.SIGINT, signal.SIG_IGN)\n" +
+        "for i in range(1000):\n" +
+        "    sleep(100)",
+        # In [6]:
         "b = 5",
     ]
     nb = _build_nb(sources)

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,0 +1,78 @@
+import os
+
+import nbformat
+
+
+pytest_plugins = "pytester"
+
+
+def test_timeouts(testdir):
+    # This test uses the testdir fixture from pytester, which is useful for
+    # testing pytest plugins. It writes a notebook to a temporary dir
+    # and then runs pytest.
+
+    # Note: The test and the notebook are defined together in order to
+    # emphasize the close dependence of the test on the structure and
+    # content of the notebook
+
+    # Setup notebook to test:
+    nb = nbformat.v4.new_notebook()
+
+    cell = nbformat.v4.new_code_cell(
+        "from time import sleep")
+    nb.cells.append(cell)
+
+    cell = nbformat.v4.new_code_cell(
+        "for i in range(100000):\n    sleep(1)\nmyvar = 5")
+    nb.cells.append(cell)
+
+    cell = nbformat.v4.new_code_cell(
+        "a = 5")
+    nb.cells.append(cell)
+
+    cell = nbformat.v4.new_code_cell(
+        "print(myvar)")
+    nb.cells.append(cell)
+
+    cell = nbformat.v4.new_code_cell(
+        "for i in range(1000):\n    sleep(100)")
+    nb.cells.append(cell)
+
+    cell = nbformat.v4.new_code_cell(
+        "b = 5")
+    nb.cells.append(cell)
+
+    # Write notebook to test dir
+    nbformat.write(nb, os.path.join(
+        str(testdir.tmpdir), 'test_timeouts.ipynb'))
+
+    # Run tests
+    result = testdir.inline_run('--nbval', '--current-env', '--nbval-cell-timeout', '5')
+    reports = result.getreports('pytest_runtest_logreport')
+
+    # Setup and teardown of cells should have no issues:
+    setup_teardown = [r for r in reports if r.when != 'call']
+    for r in setup_teardown:
+        assert r.passed
+
+    reports = [r for r in reports if r.when == 'call']
+
+    assert len(reports) == 6
+
+    # Import cell should pass:
+    assert reports[0].passed
+
+    # First timeout cell should fail, unexpectedly
+    assert reports[1].failed and not hasattr(reports[1], 'wasxfail')
+
+    # Normal cell after timeout should pass, but be expected to fail
+    assert reports[2].passed and hasattr(reports[2], 'wasxfail')
+
+    # Cell trying to access variable declare after loop in timeout
+    # should fail, expectedly (marked skipped)
+    assert reports[3].skipped and hasattr(reports[3], 'wasxfail')
+
+    # Second timeout loop should fail, expectedly, and cause all following to fail
+    assert reports[4].skipped and hasattr(reports[4], 'wasxfail')
+    assert reports[5].skipped and hasattr(reports[5], 'wasxfail')
+


### PR DESCRIPTION
Contains #39 as this was needed to test manually.

 - Adds configuration of cell timeout as `--cell-timeout`
 - If cell execution fails:
   - Interrupt kernel, try to see if we can get traceback (i.e where was it at when timeout occurred).
   - Consequent cells in the same notebook will be marked as expected failures (xfails).
 - If we time out waiting for output:
   - Halt the kernel, fail immediately
   - All following cells will be expected to fail, and will explicitly be failed.

Resolves #40.
Resolves #41.

### TODO
 - [x] Test timeout behavior when only cell execution times out
 - [x] Test timeout behavior when both cell and output times out