### PR TITLE
Metadata config by tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 /dist/
 /build/
 *.egg-info
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ install:
   - unset VIRTUAL_ENV
   # Python 3.4 and 2.7 need six installed before running setup.py
   - pip install six
+  # Travis needs to update pip/setuptools
+  - pip install --upgrade setuptools pip
   - pip install .
   # have some tests using sympy
   - pip install sympy

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -511,7 +511,7 @@ class IPyNbCell(pytest.Item):
             # 'execution_count' number which does not seems useful
             # (we will filter it in the sanitize function)
             #
-            # When the reply is display_data or execute_count,
+            # When the reply is display_data or execute_result,
             # the dictionary contains
             # a 'data' sub-dictionary with the 'text' AND the 'image/png'
             # picture (in hexadecimal). There is also a 'metadata' entry

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -621,9 +621,6 @@ class IPyNbCell(pytest.Item):
 
     def sanitize(self, s):
         """sanitize a string for comparison.
-
-        fix universal newlines, strip trailing newlines,
-        and normalize likely random values (memory addresses and UUIDs)
         """
         if not isinstance(s, six.string_types):
             return s

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         ]
     },
     install_requires = [
-        'pytest',
+        'pytest >= 2.8',
         'six',
         'jupyter_client',
         'nbformat',

--- a/tests/sample_notebook.ipynb
+++ b/tests/sample_notebook.ipynb
@@ -45,6 +45,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Different ways to ignore output differences."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
@@ -65,6 +72,76 @@
    "source": [
     "# PYTEST_VALIDATE_IGNORE_OUTPUT\n",
     "datetime.now()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2017, 1, 3, 16, 6, 20, 529355)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "datetime.now()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2017, 1, 3, 16, 6, 20, 543350)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datetime.now()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "tags": [
+     "nbval-check-output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(5)"
    ]
   },
   {

--- a/tests/sample_notebook.ipynb
+++ b/tests/sample_notebook.ipynb
@@ -144,6 +144,7 @@
     }
    ],
    "source": [
+    "# NBVAL_CHECK_OUTPUT\n",
     "# NBVAL_IGNORE_OUTPUT\n",
     "datetime.now()"
    ]

--- a/tests/sample_notebook.ipynb
+++ b/tests/sample_notebook.ipynb
@@ -124,6 +124,57 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "tags": [
+     "nbval-check-output"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2017, 1, 3, 16, 6, 20, 543350)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "datetime.now()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "tags": [
+     "nbval-ignore-output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5\n"
+     ]
+    }
+   ],
+   "source": [
+    "# NBVAL_CHECK_OUTPUT\n",
+    "# Note: This test will not check the metadata/comment precedence!\n",
+    "# It just checks that it doesn't do anything else unexpected.\n",
+    "print(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 6,
    "metadata": {
     "collapsed": false,


### PR DESCRIPTION
Resolves #5. Supersedes #22.

Details:
 - All comment markers are valid tags, except lower case and with dashes instead of underscores.
 - Comments takes precedence over metadata, as comments has a higher visibility.
 - Ignore options now write a false value to the check field. If both are defined, the *last* option will win (both for tags and for comments). We could instead enforce a check (fail/warn)?