### PR TITLE
Skip cell option

### DIFF
--- a/documentation.ipynb
+++ b/documentation.ipynb
@@ -453,6 +453,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Using tags instead of comments"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you do not want to put nbval comment annotations in your notebook, or your source language is not compatible with such annotations, you can use cell tags instead. Cell tags are strings that are added to the cell metadata under the label \"tags\", and can be added and remove using the \"Tags\" toolbar from Notebook version 5. The tags that Nbval recognizes are the same as the comment names, except lowercase, and with dashes ('-') instead of underscores ('_')."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Figures"
    ]
   },

--- a/documentation.ipynb
+++ b/documentation.ipynb
@@ -137,7 +137,9 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -251,7 +253,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Avoid specific cell executions"
+    "### Avoid output comparison for specific cells"
    ]
   },
   {
@@ -313,6 +315,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Skipping specific cells"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If, for some reason, a cell should not be executed during testing, the comment **# NBVAL_SKIP** can be used:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "# NBVAL_SKIP\n",
+    "print(\"Entering infinite loop...\")\n",
+    "while True:\n",
+    "    pass\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Checking exceptions"
    ]
   },
@@ -326,9 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -365,9 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -397,9 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -107,6 +107,7 @@ comment_markers = {
     'NBVAL_IGNORE_OUTPUT': ('check', False),
     'NBVAL_CHECK_OUTPUT': 'check',
     'NBVAL_RAISES_EXCEPTION': 'check_exception',
+    'NBVAL_SKIP': 'skip',
 }
 
 metadata_tags = {
@@ -489,6 +490,10 @@ class IPyNbCell(pytest.Item):
         output matches the output stored in the notebook.
 
         """
+        # Simply skip cell if configured to
+        if self.options['skip']:
+            pytest.skip()
+
         kernel = self.parent.kernel
         if not kernel.is_alive():
             raise NbCellError(

--- a/tests/sample_notebook.ipynb
+++ b/tests/sample_notebook.ipynb
@@ -251,6 +251,56 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## Skipping cell execution during tests\n",
+    "\n",
+    "If for some reason a cell should not be executed during testing, this can be indicated as demonstrated below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "from time import sleep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "raise Error('This should not run!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "tags": [
+     "nbval-skip"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# This cell's metadata says to skip execution\n",
+    "raise Error('Neither should this!')"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tests/sample_notebook.ipynb
+++ b/tests/sample_notebook.ipynb
@@ -46,7 +46,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Different ways to ignore output differences."
+    "## Different ways to ignore output differences\n",
+    "\n",
+    "Some of these cells ignore output by cell metadata, stored in the list \"tags\". The names of the tags are the same as the comment markers, but lowercase and with dashes instead of underscores. Various cell toolbars can be used to edit these, but the barebones version is simply to edit the raw metadata."
    ]
   },
   {
@@ -112,6 +114,7 @@
     }
    ],
    "source": [
+    "# This cell uses metadata to ignore output\n",
     "datetime.now()"
    ]
   },
@@ -136,6 +139,7 @@
     }
    ],
    "source": [
+    "# This cell's metadata says to check output, but comments take precedence\n",
     "# NBVAL_CHECK_OUTPUT\n",
     "# NBVAL_IGNORE_OUTPUT\n",
     "datetime.now()"
@@ -160,8 +164,8 @@
    ],
    "source": [
     "# NBVAL_CHECK_OUTPUT\n",
-    "# Note: This test will not check the metadata/comment precedence!\n",
-    "# It just checks that it doesn't do anything else unexpected.\n",
+    "# This cell's metadata says to ignore output, but comments take precedence\n",
+    "# Note to developers: Even if this behavior gets broken, it will not cause this cell to fail!\n",
     "print(5)"
    ]
   },
@@ -183,6 +187,7 @@
     }
    ],
    "source": [
+    "# This cell's metadata says to check output\n",
     "print(5)"
    ]
   },
@@ -256,6 +261,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 2",
    "language": "python",

--- a/tests/sample_notebook.ipynb
+++ b/tests/sample_notebook.ipynb
@@ -17,9 +17,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -54,9 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -77,9 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -101,7 +95,6 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "nbval-ignore-output"
     ]
@@ -126,7 +119,6 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "nbval-check-output"
     ]
@@ -153,7 +145,6 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "nbval-ignore-output"
     ]
@@ -178,7 +169,6 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": false,
     "tags": [
      "nbval-check-output"
     ]
@@ -199,9 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -223,7 +211,6 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [
@@ -288,5 +275,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
Adds a comment marker `# NBVAL_SKIP`, which indicates that a cell should not be executed (marked as skipped in test report).

Resolves #17.