### PR TITLE
Give kernel a little more time with outputs

### DIFF
--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -529,7 +529,7 @@ class IPyNbCell(pytest.Item):
         self.test_outputs = outs
 
         # Now get the outputs from the iopub channel, need smaller timeout
-        output_timeout = 5
+        output_timeout = 10
         while True:
             # The iopub channel broadcasts a range of messages. We keep reading
             # them until we find the message containing the side-effects of our


### PR DESCRIPTION
After finished execution, we want the kernel to send us the outputs it has. We currently wait for that output for 5 seconds before calling it a failure. On slower systems (e.g. busy CI) this might take a little longer, so this PR bumps the timeout to 10 seconds.

Not sure if this is the best solution or not, but it is definitely the simplest.

Note: This will slow down each test run with 5 seconds, as we test failing of this timeout as well.