### PR TITLE
Fix intermittent test suite failures

### DIFF
--- a/nbval/kernel.py
+++ b/nbval/kernel.py
@@ -6,6 +6,13 @@ Authors: D. Cortes, O. Laslett, T. Kluyver, H. Fangohr, V.T. Fauske
 """
 
 import os
+import logging
+from pprint import pformat
+
+try:
+    from Queue import Empty
+except:
+    from queue import Empty
 
 # Kernel for jupyter notebooks
 from jupyter_client.manager import KernelManager
@@ -14,6 +21,11 @@ import ipykernel.kernelspec
 
 
 CURRENT_ENV_KERNEL_NAME = ':nbval-parent-env'
+
+logger = logging.getLogger('nbval')
+# Uncomment to debug kernel communication:
+# logger.setLevel('DEBUG')
+# logging.basicConfig(format="[%(asctime)s - %(name)s - %(levelname)s] %(message)s")
 
 
 class NbvalKernelspecManager(KernelSpecManager):
@@ -35,6 +47,7 @@ class NbvalKernelspecManager(KernelSpecManager):
 
 def start_new_kernel(startup_timeout=60, kernel_name='python', **kwargs):
     """Start a new kernel, and return its Manager and Client"""
+    logger.debug('Starting new kernel: "%s"' % kernel_name)
     km = KernelManager(kernel_name=kernel_name,
                        kernel_spec_manager=NbvalKernelspecManager())
     km.start_kernel(**kwargs)
@@ -43,6 +56,7 @@ def start_new_kernel(startup_timeout=60, kernel_name='python', **kwargs):
     try:
         kc.wait_for_ready(timeout=startup_timeout)
     except RuntimeError:
+        logger.exception('Failure starting kernel "%s"', kernel_name)
         kc.stop_channels()
         km.shutdown_kernel()
         raise
@@ -78,10 +92,18 @@ class RunningKernel(object):
         Timeout is None by default
         When timeout is reached
         """
-        if stream == 'iopub':
-            return self.kc.get_iopub_msg(timeout=timeout)
-        elif stream == 'shell':
-            return self.kc.get_shell_msg(timeout=timeout)
+        try:
+            if stream == 'iopub':
+                msg = self.kc.get_iopub_msg(timeout=timeout)
+            elif stream == 'shell':
+                msg = self.kc.get_shell_msg(timeout=timeout)
+            else:
+                raise ValueError('Invalid stream specified: "%s"' % stream)
+        except Empty:
+            logger.debug('Kernel: Timeout waiting for message on %s' % stream)
+            raise
+        logger.debug("Kernel message (%s):\n%s" % (stream, pformat(msg)))
+        return msg
 
     def execute_cell_input(self, cell_input, allow_stdin=None):
         """
@@ -92,6 +114,10 @@ class RunningKernel(object):
         Function returns a unique message id of the reply from
         the kernel.
         """
+        if cell_input:
+            logger.debug('Executing cell: "%s"...' % (cell_input.splitlines()[0][:40]))
+        else:
+            logger.debug('Executing empty cell')
         return self.kc.execute(cell_input, allow_stdin=allow_stdin, stop_on_error=False)
 
     def is_alive(self):
@@ -105,6 +131,7 @@ class RunningKernel(object):
         """
         Instructs the kernel manager to restart the kernel process now.
         """
+        logger.debug('Restarting kernel')
         self.km.restart_kernel(now=True)
 
     def interrupt(self):
@@ -112,6 +139,7 @@ class RunningKernel(object):
         Instructs the kernel to stop whatever it is doing, and await
         further commands.
         """
+        logger.debug('Interrupting kernel')
         self.km.interrupt_kernel()
 
     def stop(self):
@@ -119,6 +147,7 @@ class RunningKernel(object):
         Instructs the kernel process to stop channels
         and the kernel manager to then shutdown the process.
         """
+        logger.debug('Stopping kernel')
         self.kc.stop_channels()
         self.km.shutdown_kernel(now=True)
         del self.km

--- a/nbval/kernel.py
+++ b/nbval/kernel.py
@@ -92,7 +92,7 @@ class RunningKernel(object):
         Function returns a unique message id of the reply from
         the kernel.
         """
-        return self.kc.execute(cell_input, allow_stdin=allow_stdin)
+        return self.kc.execute(cell_input, allow_stdin=allow_stdin, stop_on_error=False)
 
     def is_alive(self):
         if hasattr(self, 'km'):

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -542,7 +542,7 @@ class IPyNbCell(pytest.Item):
         self.test_outputs = outs
 
         # Now get the outputs from the iopub channel, need smaller timeout
-        output_timeout = 10
+        output_timeout = 5
         while True:
             # The iopub channel broadcasts a range of messages. We keep reading
             # them until we find the message containing the side-effects of our

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -533,6 +533,7 @@ class IPyNbCell(pytest.Item):
         # after code is sent for execution, the kernel sends a message on
         # the shell channel. Timeout if no message received.
         timeout = self.config.option.nbval_cell_timeout
+        timed_out_this_run = False
 
         # Poll the shell channel to get a message
         while True:
@@ -543,6 +544,7 @@ class IPyNbCell(pytest.Item):
                 # Try to interrupt kernel, as this will give us traceback:
                 kernel.interrupt()
                 self.parent.timed_out = True
+                timed_out_this_run = True
                 break
 
             # Is this the message we are waiting for?
@@ -573,7 +575,7 @@ class IPyNbCell(pytest.Item):
                 # if the time is out (when the cell stops to be executed?)
                 # Halt kernel here!
                 kernel.stop()
-                if self.parent.timed_out:
+                if timed_out_this_run:
                     self.raise_cell_error(
                         "Timeout of %g seconds exceeded while executing cell."
                         " Failed to interrupt kernel in %d seconds, so "

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -52,7 +52,7 @@ def test_timeouts(testdir):
         str(testdir.tmpdir), 'test_timeouts.ipynb'))
 
     # Run tests
-    result = testdir.inline_run('--nbval', '--current-env', '--nbval-cell-timeout', '5')
+    result = testdir.inline_run('--nbval', '--current-env', '--nbval-cell-timeout', '5', '-s')
     reports = result.getreports('pytest_runtest_logreport')
 
     # Setup and teardown of cells should have no issues:

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 import nbformat
 
 
@@ -63,13 +65,16 @@ def test_timeouts(testdir):
     assert len(reports) == 6
 
     # Import cell should pass:
-    assert reports[0].passed
+    if not reports[0].passed:
+        pytest.fail("Inner exception: %s" % reports[0].longreprtext)
 
     # First timeout cell should fail, unexpectedly
     assert reports[1].failed and not hasattr(reports[1], 'wasxfail')
 
     # Normal cell after timeout should pass, but be expected to fail
-    assert reports[2].passed and hasattr(reports[2], 'wasxfail')
+    if not reports[2].passed:
+        pytest.fail("Inner exception: %s" % reports[2].longreprtext)
+    assert hasattr(reports[2], 'wasxfail')
 
     # Cell trying to access variable declare after loop in timeout
     # should fail, expectedly (marked skipped)


### PR DESCRIPTION
This should fix the intermittent CI failures seen, and as discussed in #46.

The root of the issue was that after an exception occurred in the kernel, it would previously clear all execution requests. If a new execution request (the next cell to test) was submitted before this operation completed, the subsequent request would be aborted. This was exasperated by the unexpected behavior of not getting an `idle` message for the new request.

This PR solves this by setting the `stop_on_error` flag of the kernel to false, which will prevent the error from clearing all execution requests. Other changes include:
 - Better error reporting of internal errors.
 - Making code more robust to similar errors.
 - Adding debug logging to kernel coms (off by default).