### PR TITLE
Add coverage collection from notebook execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ install:
   - pip install sympy
   # and some use matplotlib
   - pip install matplotlib
+  # and coverage
+  - pip install pytest-cov
 
 # command to run tests
 script: make test

--- a/nbval/cover.py
+++ b/nbval/cover.py
@@ -1,0 +1,47 @@
+"""
+Code to enable coverage of any external code called by the
+notebook.
+"""
+
+_python_setup = """\
+import coverage
+
+__cov = coverage.Coverage(source=%r, config_file=%r, data_suffix='nbval')
+__cov.start()
+"""
+_python_teardown = """\
+__cov.stop()
+__cov.save()
+"""
+
+
+def setup_coverage(config, kernel, floc, output_loc=None):
+    """Start coverage reporting on kernel
+
+    Currently supported kernel languages are:
+     - Python
+    """
+    language = kernel.language
+    if language.startswith('python'):
+        # Get options from pytest's own coverage module
+        source = config.option.cov_source
+        config_file = config.option.cov_config
+        cmd = _python_setup % (source, config_file)
+        msg_id = kernel.kc.execute(cmd, stop_on_error=False)
+        kernel.await_idle(msg_id, 60)  # A minute should be plenty to enable coverage
+    else:
+        config.warn('C1',
+            'Coverage currently not supported for language "%s".' % language,
+            floc)
+        return
+
+
+def teardown_coverage(config, kernel, output_loc=None):
+    language = kernel.language
+    if language.startswith('python'):
+        msg_id = kernel.kc.execute(_python_teardown)
+        kernel.await_idle(msg_id, 60)  # A minute should be plenty to write out coverage
+    else:
+        # Warnings should be given on setup, or there might be no teardown
+        # for a specific language, so do nothing here
+        pass

--- a/nbval/kernel.py
+++ b/nbval/kernel.py
@@ -120,6 +120,27 @@ class RunningKernel(object):
             logger.debug('Executing empty cell')
         return self.kc.execute(cell_input, allow_stdin=allow_stdin, stop_on_error=False)
 
+
+    def await_idle(self, msg_id, timeout=None):
+        """
+        Continuously poll the kernel 'shell' stream for messages until:
+         - It receives an 'idle' status for the given message id
+         - The timeout is reached awaiting a message, in which case
+           a `Queue.Empty` exception will be raised.
+        """
+        while True:
+            msg = self.get_message(stream='shell', timeout=timeout)
+
+            # Is this the message we are waiting for?
+            if msg['parent_header'].get('msg_id') == msg_id:
+                if msg['content']['status'] == 'aborted':
+                    # This should not occur!
+                    raise RuntimeError('Kernel aborted execution request')
+                return
+            else:
+                continue
+
+
     def is_alive(self):
         if hasattr(self, 'km'):
             return self.km.is_alive()

--- a/nbval/kernel.py
+++ b/nbval/kernel.py
@@ -151,3 +151,9 @@ class RunningKernel(object):
         self.kc.stop_channels()
         self.km.shutdown_kernel(now=True)
         del self.km
+
+    @property
+    def language(self):
+        if self.km.kernel_spec is None:
+            return None
+        return self.km.kernel_spec.language

--- a/nbval/kernel.py
+++ b/nbval/kernel.py
@@ -137,8 +137,6 @@ class RunningKernel(object):
                     # This should not occur!
                     raise RuntimeError('Kernel aborted execution request')
                 return
-            else:
-                continue
 
 
     def is_alive(self):

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -29,6 +29,7 @@ from nbformat import NotebookNode
 
 # Kernel for running notebooks
 from .kernel import RunningKernel, CURRENT_ENV_KERNEL_NAME
+from .cover import setup_coverage, teardown_coverage
 
 
 # define colours for pretty outputs
@@ -219,6 +220,8 @@ class IPyNbFile(pytest.File):
                 'kernelspec', {}).get('name', 'python')
         self.kernel = RunningKernel(kernel_name)
         self.setup_sanitize_files()
+        if getattr(self.parent.config.option, 'cov_source', None):
+            setup_coverage(self.parent.config, self.kernel, getattr(self, "fspath", None))
 
 
     def setup_sanitize_files(self):
@@ -296,6 +299,8 @@ class IPyNbFile(pytest.File):
 
     def teardown(self):
         if self.kernel is not None and self.kernel.is_alive():
+            if getattr(self.parent.config.option, 'cov_source', None):
+                teardown_coverage(self.parent.config, self.kernel)
             self.kernel.stop()
 
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,60 @@
+
+import os
+import re
+
+import nbformat
+from utils import build_nb, add_expected_plaintext_outputs
+
+pytest_plugins = "pytester"
+
+
+_re_coverage_report_line = re.compile('^(\w)\s*(\d+)\s*(\d+)\s*(\d+)%$')
+
+
+def test_coverage(testdir):
+
+    testdir.makepyfile(
+        # Setup file to cover:
+        lib="""
+            def mysum(a, b):
+                return a + b
+            def myprod(a, b):
+                return a * b
+        """,
+        # Setup python file to cover mysum function
+        test_lib="""
+            import lib
+            def test_sum():
+                assert lib.mysum(1, 3) == 4
+                assert lib.mysum("cat", "dog") == "catdog"
+                assert lib.mysum(1.5, 2) == 3.5
+        """,
+    )
+
+    # Setup notebook to cover myprod function
+    nb = build_nb([
+        "import lib",
+        "lib.myprod(1, 3)",
+        "lib.myprod(2.5, 2.5)",
+        "lib.myprod(2, 'cat')"
+    ])
+    add_expected_plaintext_outputs(nb, [
+        None, "3", "6.25", "'catcat'"
+    ])
+    # Write notebook to test dir
+    nbformat.write(nb, os.path.join(
+        str(testdir.tmpdir), 'test_timeouts.ipynb'))
+
+    # Run tests
+    result = testdir.runpytest_inprocess('--nbval', '--current-env', '--cov', '.')
+
+    # Check tests went off as they should:
+    result.ret == 0
+
+    # Ensure coverage report was generated:
+    assert os.path.exists(os.path.join(str(testdir.tmpdir), '.coverage'))
+
+    # Check that all lines were covered:
+    result.stdout.fnmatch_lines([
+        'lib.py*4*0*100%'
+    ])

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -1,19 +1,13 @@
 import os
 
+import nbformat
+
 import pytest
 
-import nbformat
+from utils import build_nb
 
 
 pytest_plugins = "pytester"
-
-
-def _build_nb(sources):
-    """Builds a notebook of only code cells, from a list of sources"""
-    nb = nbformat.v4.new_notebook()
-    for src in sources:
-        nb.cells.append(nbformat.v4.new_code_cell(src))
-    return nb
 
 
 def test_timeouts(testdir):
@@ -45,7 +39,7 @@ def test_timeouts(testdir):
         # In [6]:
         "b = 5",
     ]
-    nb = _build_nb(sources)
+    nb = build_nb(sources)
 
     # Write notebook to test dir
     nbformat.write(nb, os.path.join(
@@ -83,4 +77,3 @@ def test_timeouts(testdir):
     # Second timeout loop should fail, expectedly, and cause all following to fail
     assert reports[4].skipped and hasattr(reports[4], 'wasxfail')
     assert reports[5].skipped and hasattr(reports[5], 'wasxfail')
-

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,23 @@
+
+import nbformat
+
+
+def build_nb(sources):
+    """Builds a notebook of only code cells, from a list of sources
+    """
+    nb = nbformat.v4.new_notebook()
+    for src in sources:
+        nb.cells.append(nbformat.v4.new_code_cell(src))
+    return nb
+
+
+def add_expected_plaintext_outputs(nb, outputs):
+    for i, (cell, text) in enumerate(zip(nb.cells, outputs)):
+        if text is None:
+            continue
+        output = nbformat.v4.new_output(
+            'execute_result',
+            data={'text/plain': [text]},
+            execution_count=i,
+            )
+        cell.outputs.append(output)


### PR DESCRIPTION
Resolves #7.

Adds support for having code executed in notebooks cover imported code (for python). Two details of the implementation that needs feedback:
 - Currently it implements the testing by executing coverage code before and after notebook cells. This has the following side effects: `coverage` is imported; a `__cov` global object is stored; `__cov` is assumed to still exist at end of execution (and will error if not). An alternative is to use `coverage run` as the kernel executable (this handles it in a cleaner way), but this is a lot more tricky to get right, and might be brittle.
 - Currently it piggy-backs on the options of `pytest-cov`. This implies that it is always on/off when normal coverage is on/off. It might not always be wanted to have nbval exercise the code (it might simply not be rigorous enough to be considered covered). We might therefore consider override options `--nbval-cov` (and `--no-nbval-cov`?).

### TODO:
 - [x] Tests of coverage functionality