### PR TITLE
Refactor comparison of outputs

### DIFF
--- a/tests/test_coalesce.ipynb
+++ b/tests/test_coalesce.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import print_function\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Foo!\n",
+      "Bar!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Foo!')\n",
+    "print('Bar!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Bar!\n",
+      "Foo!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Bar!', file=sys.stderr)\n",
+    "print('Foo!', file=sys.stderr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Combo breaker!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Bar!\n",
+      "Foo!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Bar!', file=sys.stderr)\n",
+    "print('Combo breaker!', file=sys.stdout)\n",
+    "print('Foo!', file=sys.stderr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Bar!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Combo breaker!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Foo!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Bar!', file=sys.stderr)\n",
+    "sys.stderr.flush()\n",
+    "print('Combo breaker!', file=sys.stdout)\n",
+    "sys.stdout.flush()\n",
+    "print('Foo!', file=sys.stderr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Bar!\n",
+      "Foo!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Combo breaker!\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "import numpy as np\n",
+    "print('Bar!', file=sys.stderr)\n",
+    "# Do not run the next line when regenerating test!\n",
+    "sys.stderr.flush()\n",
+    "print('Combo breaker!', file=sys.stdout)\n",
+    "sys.stderr.flush()\n",
+    "print('Foo!', file=sys.stderr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This adjusts the way outputs are handled such that collected outputs are still valid outputs (needed for visualization with nbdime), but streams are again concatenated for comparison.

It also changes how outputs are compared (no longer merges all outputs of same MIME-type into one giant string, but behaves the same way). This point should make outputs a little better when failing.

Fixes #54, #55, #56.