### PR TITLE
Add raises-exception as tag for ignoring exceptions

### DIFF
--- a/documentation.ipynb
+++ b/documentation.ipynb
@@ -460,7 +460,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you do not want to put nbval comment annotations in your notebook, or your source language is not compatible with such annotations, you can use cell tags instead. Cell tags are strings that are added to the cell metadata under the label \"tags\", and can be added and remove using the \"Tags\" toolbar from Notebook version 5. The tags that Nbval recognizes are the same as the comment names, except lowercase, and with dashes ('-') instead of underscores ('_')."
+    "If you do not want to put nbval comment annotations in your notebook, or your source language is not compatible with such annotations, you can use cell tags instead. Cell tags are strings that are added to the cell metadata under the label \"tags\", and can be added and remove using the \"Tags\" toolbar from Notebook version 5. The tags that Nbval recognizes are the same as the comment names, except lowercase, and with dashes ('-') instead of underscores ('\\_'). For instance, the comment \"`NBVAL_IGNORE_OUTPUT`\" becomes the tag \"`nbval-ignore-output`\".  However, for \"`NBVAL_RAISES_EXCEPTION`\", either \"`nbval-raises-exception`\" or the plain \"`raises-exception`\" tag can be used, since as of Notebook 5.1, the latter is a special tag that tells the Notebook cell executor to continue running normally after an exception is raised."
    ]
   },
   {
@@ -548,7 +548,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -119,6 +119,8 @@ metadata_tags = {
     for (k, v) in comment_markers.items()
 }
 
+metadata_tags['raises-exception'] = 'check_exception'
+
 
 def find_comment_markers(cellsource):
     """Look through the cell source for comments which affect nbval's behaviour

--- a/tests/exceptions.ipynb
+++ b/tests/exceptions.ipynb
@@ -74,20 +74,20 @@
    },
    "outputs": [
     {
-     "ename": "ZeroDivisionError",
-     "evalue": "division by zero",
+     "ename": "RuntimeError",
+     "evalue": "Ignore me",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mZeroDivisionError\u001b[0m                         Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-1-aefb18df2e92>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# this cell has a metadata tag of \"nbval-raises-exception\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;36m2\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mZeroDivisionError\u001b[0m: division by zero"
+      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-1-ee0af46286bb>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# this cell has a metadata tag of \"nbval-raises-exception\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32mraise\u001b[0m \u001b[0mRuntimeError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Ignore me\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mRuntimeError\u001b[0m: Ignore me"
      ]
     }
    ],
    "source": [
     "# this cell has a metadata tag of \"nbval-raises-exception\"\n",
-    "2 / 0"
+    "raise RuntimeError(\"Ignore me\")"
    ]
   },
   {
@@ -100,20 +100,20 @@
    },
    "outputs": [
     {
-     "ename": "ZeroDivisionError",
-     "evalue": "division by zero",
+     "ename": "RuntimeError",
+     "evalue": "Ignore me also",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mZeroDivisionError\u001b[0m                         Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-2-35f2844b74bf>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# this cell has a metadata tag of \"raises-exception\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;36m3\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;31mZeroDivisionError\u001b[0m: division by zero"
+      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-657a1b0a050c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# this cell has a metadata tag of \"raises-exception\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32mraise\u001b[0m \u001b[0mRuntimeError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Ignore me also\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mRuntimeError\u001b[0m: Ignore me also"
      ]
     }
    ],
    "source": [
     "# this cell has a metadata tag of \"raises-exception\"\n",
-    "3 / 0"
+    "raise RuntimeError(\"Ignore me also\")"
    ]
   },
   {

--- a/tests/exceptions.ipynb
+++ b/tests/exceptions.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "ename": "RuntimeError",
@@ -38,9 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -70,15 +66,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
-    "collapsed": true
+    "tags": [
+     "nbval-raises-exception"
+    ]
    },
+   "outputs": [
+    {
+     "ename": "ZeroDivisionError",
+     "evalue": "division by zero",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mZeroDivisionError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-1-aefb18df2e92>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# this cell has a metadata tag of \"nbval-raises-exception\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;36m2\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mZeroDivisionError\u001b[0m: division by zero"
+     ]
+    }
+   ],
+   "source": [
+    "# this cell has a metadata tag of \"nbval-raises-exception\"\n",
+    "2 / 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [
+    {
+     "ename": "ZeroDivisionError",
+     "evalue": "division by zero",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mZeroDivisionError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-35f2844b74bf>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# this cell has a metadata tag of \"raises-exception\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;36m3\u001b[0m \u001b[0;34m/\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mZeroDivisionError\u001b[0m: division by zero"
+     ]
+    }
+   ],
+   "source": [
+    "# this cell has a metadata tag of \"raises-exception\"\n",
+    "3 / 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
+  "celltoolbar": "Tags",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -94,7 +141,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Following on the ability to use tags to detect known exception raising, https://github.com/jupyter/notebook/issues/2516 implemented in https://github.com/jupyter/notebook/pull/2549 allows Jupyter notebook to use a tag to indicate that code execution should not halt because it encountered an exception.  However the tag that that team wanted "raises-exception" is unprefixed -- this commit allows nbval (which is amazing btw!) to use the unprefixed tag in addition to the nbval-raises-exception version