### PR TITLE
Ensure conf warning messages are strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
   - "3.5"
   - "3.4"
   - "2.7"
+matrix:
+  allow_failures:
+    - python: "nightly"
 
 install:
   # We do this conditionally because it saves us some downloading if the

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -284,7 +284,7 @@ class IPyNbFile(pytest.File):
                     for w in ws:
                         self.parent.config.warn(
                             "C1",
-                            w.message,
+                            str(w.message),
                             '%s:Cell %d' % (
                                 getattr(self, "fspath", None),
                                 cell_num))


### PR DESCRIPTION
Fixes error when giving configuration warnings with pytest >= 3.1 (still compatible with older versions). Fixes CI problem in #64.