### PR TITLE
Don't compare outputs when ref cell is unexecuted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ __pycache__
 **/build/
 *.egg-info
 .cache
-.doit.db
+.doit.db*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
+# environment variables
+environment:
+  matrix:
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_MAJOR: 3
+      PYTHON_ARCH: "64"
+
+# scripts that run after cloning repository
+install:
+  # Ensure python scripts are from right version:
+  - 'SET "PATH=%PYTHON%\Scripts;%PYTHON%;%PATH%"'
+  # Update pip/setuptools:
+  - pip install --upgrade setuptools pip
+  # Install our package:
+  - pip install .
+  - pip install doit
+  - doit install_test_deps
+
+build: off
+
+# to run your custom scripts instead of automatic tests
+test_script:
+  - doit test

--- a/docs/source/index.ipynb
+++ b/docs/source/index.ipynb
@@ -315,6 +315,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note that unexecuted cells will always skip its output check:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('This is not going to be tested when unrun')\n",
+    "print(np.random.randint(1, 20000))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Skipping specific cells"
    ]
   },

--- a/dodo.py
+++ b/dodo.py
@@ -1,29 +1,43 @@
-PYTHON = "python3"
+import sys
+PYTHON = sys.executable
 
 DOIT_CONFIG = {
     'default_tasks': ['test'],
     'verbosity': 2,
 }
 
+def _make_cmd(cmd):
+    import os
+    if os.name == 'nt':
+        return ' '.join(cmd)
+    return cmd
+
+def _clean_dist_cmd():
+    import shutil
+    try:
+        shutil.rmtree("dist")
+    except FileNotFoundError:
+        pass
+
 def task_test():
     return {
         'actions': [
-            ["py.test", "-v", "tests/", "--nbval", "--current-env", "--sanitize-with", "tests/sanitize_defaults.cfg", "--ignore", "tests/ipynb-test-samples"],
+            _make_cmd(["py.test", "-v", "tests/", "--nbval", "--current-env", "--sanitize-with", "tests/sanitize_defaults.cfg", "--ignore", "tests/ipynb-test-samples"]),
         ],
     }
 
 def task_install_test_deps():
     test_deps = ['matplotlib', 'sympy', 'pytest-cov']
     return {
-        'actions': [['pip', 'install'] + test_deps],
+        'actions': [_make_cmd(['pip', 'install'] + test_deps)],
     }
 
 def task_build_dists():
     return {
         'actions': [
-            ["rm", "-rf", "dist/"],
-            [PYTHON, "setup.py", "sdist"],
-            [PYTHON, "setup.py", "bdist_wheel"],
+            (_clean_dist_cmd,),
+            _make_cmd([PYTHON, "setup.py", "sdist"]),
+            _make_cmd([PYTHON, "setup.py", "bdist_wheel"]),
         ],
     }
 

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -696,13 +696,18 @@ class IPyNbCell(pytest.Item):
 
         outs[:] = coalesce_streams(outs)
 
+        # Cells where the reference is not run, will not check outputs:
+        unrun = self.cell.execution_count is None
+        if unrun and self.cell.outputs:
+            self.raise_cell_error('Unrun reference cell has outputs')
+
         # Compare if the outputs have the same number of lines
         # and throw an error if it fails
         # if len(outs) != len(self.cell.outputs):
         #     self.diff_number_outputs(outs, self.cell.outputs)
         #     failed = True
         failed = False
-        if self.options['check']:
+        if self.options['check'] and not unrun:
             if not self.compare_outputs(outs, coalesce_streams(self.cell.outputs)):
                 failed = True
 

--- a/tests/ipynb-test-samples/test-stream-pass-missing-unexecuted-output.ipynb
+++ b/tests/ipynb-test-samples/test-stream-pass-missing-unexecuted-output.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "test\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('test')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# An unexecuted cell has an implicit skip of output check\n",
+    "print('test')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "test\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('test')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
- Ignore outputs when reference cell is unexecuted (`execution_count is None`).
- Fix doit script for Windows.
- Add appveyor config to run CI for Windows.