### PR TITLE
Do not compare widget views MIME data

### DIFF
--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -212,6 +212,7 @@ class IPyNbFile(pytest.File):
             'output_type',
             'name',
             'execution_count',
+            'application/vnd.jupyter.widget-view+json'  # Model IDs are random
         )
         if not config.option.nbdime:
             self.skip_compare = self.skip_compare + ('image/png', 'image/jpeg')


### PR DESCRIPTION
Widget views are simply version numbers and a random model id (uuid). The default repr of the widget should be reasonably sufficient for comparing widgets.