### PR TITLE
Use a MULTILINE anchored regex when removing carriage returns

### DIFF
--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -795,7 +795,7 @@ class IPyNbCell(pytest.Item):
         return s
 
 
-carriagereturn_pat = re.compile(r'.*\r(?=[^\n])')
+carriagereturn_pat = re.compile(r'^.*\r(?=[^\n])', re.MULTILINE)
 backspace_pat = re.compile(r'[^\n]\b')
 
 


### PR DESCRIPTION
This seems a lot faster on long strings (8s down to 8ms for a 120000-char
string).