### PR TITLE
Mark nbval as incompatible with coverage 5.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'jupyter_client',
         'nbformat',
         'ipykernel',
-        'coverage'
+        'coverage < 5',  # until gh-129 is fixed
     ],
     classifiers = [
         'Framework :: IPython',


### PR DESCRIPTION
This makes the error for gh-129 much clearer, and makes the workaround for the end user obvious too