### PR TITLE
Group nbval command line options under 'nbval'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ notebook are run on the same kernel.
 ## Help
 The `py.test` system help can be obtained with `py.test -h`, which will
 show all the flags that can be passed to the command, such as the
-verbose `-v` option. The IPython notebook plugin can be found under the
-`general` section.
+verbose `-v` option. Nbval's options can be found under the
+`Jupyter Notebook validation` section.
 
 
 ## Acknowledgements

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -71,9 +71,10 @@ def pytest_addoption(parser):
 
     This is called by the pytest API
     """
-    group = parser.getgroup("general")
+    group = parser.getgroup("nbval", "Jupyter Notebook validation")
+
     group.addoption('--nbval', action='store_true',
-                    help="Validate Jupyter notebooks")
+                    help="Run Jupyter notebooks, validating all output")
 
     group.addoption('--nbval-lax', action='store_true',
                     help="Run Jupyter notebooks, only validating output on "


### PR DESCRIPTION
I _think_ this would just be a cosmetic change.

Example output of `pytest --help` (with e.g. coverage plugin also present)...

Before:
```
general:
  -k EXPRESSION         only run tests which match the given substring expression.
  -m MARKEXPR           only run tests matching given mark expression. example: -m
                        'mark1 and not mark2'.

[...]

  --nbval               Validate Jupyter notebooks
  --nbval-lax           Run Jupyter notebooks, only validating output on cells
                        marked with # NBVAL_CHECK_OUTPUT
  --sanitize-with=SANITIZE_WITH
                        File with regex expressions to sanitize the outputs. This
                        option only works when the --nbval flag is passed to py.test
  --current-env         Force test execution to use a python kernel in the same
                        environment that py.test was launched from. Without this
                        flag, the kernel stored in the notebook is used by default.
                        See also: --kernel-name
  --kernel-name=KERNEL_NAME
                        Force test execution to use the named kernel. If a kernel is
                        not named, the kernel stored in the notebook is used by
                        default. See also: --current-env
  --nbval-cell-timeout=NBVAL_CELL_TIMEOUT
                        Timeout for cell execution, in seconds.

[...]

coverage reporting with distributed testing support:
  --cov=[SOURCE]        Path or package name to measure during execution (multi-
                        allowed). Use --cov= to not do any source filtering and
                        record everything.
  --cov-report=TYPE     Type of report to generate: term, term-missing, annotate,
                        html, xml (multi-allowed). term, term-missing may be
                        followed by ":skip-covered". annotate, html and xml may be
                        followed by ":DEST" where DEST specifies the output
                        location. Use --cov-report= to not generate any output.
  --cov-config=PATH     Config file for coverage. Default: .coveragerc
  --no-cov-on-fail      Do not report coverage if test run fails. Default: False
  --no-cov              Disable coverage report completely (useful for debuggers).
                        Default: False
  --cov-fail-under=MIN  Fail if the total coverage is less than MIN.
  --cov-append          Do not delete coverage but append to current. Default: False
  --cov-branch          Enable branch coverage.
  --cov-context=CONTEXT
                        Dynamic contexts to use. "test" for now.
```

After:
```
general:
  -k EXPRESSION         only run tests which match the given substring expression.
  -m MARKEXPR           only run tests matching given mark expression. example: -m
                        'mark1 and not mark2'.

[...]

coverage reporting with distributed testing support:
  --cov=[SOURCE]        Path or package name to measure during execution (multi-allowed). Use --cov= to not do any source filtering and record everything.
  --cov-report=TYPE     Type of report to generate: term, term-missing, annotate, html, xml (multi-allowed). term, term-missing may be followed by ":skip-covered".
                        annotate, html and xml may be followed by ":DEST" where DEST specifies the output location. Use --cov-report= to not generate any output.
  --cov-config=PATH     Config file for coverage. Default: .coveragerc
  --no-cov-on-fail      Do not report coverage if test run fails. Default: False
  --no-cov              Disable coverage report completely (useful for debuggers). Default: False
  --cov-fail-under=MIN  Fail if the total coverage is less than MIN.
  --cov-append          Do not delete coverage but append to current. Default: False
  --cov-branch          Enable branch coverage.
  --cov-context=CONTEXT
                        Dynamic contexts to use. "test" for now.

Jupyter Notebook validation:
  --nbval               Run Jupyter notebooks, validating all output
  --nbval-lax           Run Jupyter notebooks, only validating output on cells marked with # NBVAL_CHECK_OUTPUT
  --sanitize-with=SANITIZE_WITH
                        File with regex expressions to sanitize the outputs. This option only works when the --nbval flag is passed to py.test
  --current-env         Force test execution to use a python kernel in the same enviornment that py.test was launched from.
  --nbval-cell-timeout=NBVAL_CELL_TIMEOUT
                        Timeout for cell execution, in seconds.
```

Note that grouping options is suggested in the pytest plugin cookiecutter:

https://github.com/pytest-dev/cookiecutter-pytest-plugin/blob/master/pytest-%7B%7Bcookiecutter.plugin_name%7D%7D/pytest_%7B%7Bcookiecutter.module_name%7D%7D.py#L7