### PR TITLE
Add option to specify a kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Specify `-p no:python` if you would like to execute notebooks only. Alternativel
 
     py.test --nbval my_notebook.ipynb
 
+By default, each `.ipynb` file will be executed using the kernel
+specified in its metadata. You can override this behavior by passing
+either `--nbval-kernel-name mykernel` to run all the notebooks using
+`mykernel`, or `--current-env` to use a kernel in the same environment
+in which pytest itself was launched.
+
 If the output lines are going to be sanitized, an extra flag, `--sanitize-with`
 together with the path to a confguration file with regex expressions, must be passed,
 i.e.

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -89,9 +89,9 @@ def pytest_addoption(parser):
                          'the same environment that py.test was '
                          'launched from. Without this flag, the kernel stored '
                          'in the notebook is used by default. '
-                         'See also: --kernel-name')
+                         'See also: --nbval-kernel-name')
 
-    group.addoption('--kernel-name', action='store', default=None,
+    group.addoption('--nbval-kernel-name', action='store', default=None,
                     help='Force test execution to use the named kernel. '
                          'If a kernel is not named, the kernel stored in the '
                          'notebook is used by default. '
@@ -113,8 +113,8 @@ def pytest_configure(config):
         reporter = NbdimeReporter(config, sys.stdout)
         config.pluginmanager.register(reporter, 'nbdimereporter')
     if config.option.nbval or config.option.nbval_lax:
-        if config.option.kernel_name and config.option.current_env:
-            raise ValueError("--current-env and --kernel-name are mutually exclusive.")
+        if config.option.nbval_kernel_name and config.option.current_env:
+            raise ValueError("--current-env and --nbval-kernel-name are mutually exclusive.")
 
 
 
@@ -236,12 +236,12 @@ class IPyNbFile(pytest.File):
         Called by pytest to setup the collector cells in .
         Here we start a kernel and setup the sanitize patterns.
         """
-        # we've already checked that --current-env and --kernel-name
-        # were not both supplied
+        # we've already checked that --current-env and
+        # --nbval-kernel-name were not both supplied
         if self.parent.config.option.current_env:
             kernel_name = CURRENT_ENV_KERNEL_NAME
-        elif self.parent.config.option.kernel_name:
-            kernel_name = self.parent.config.option.kernel_name
+        elif self.parent.config.option.nbval_kernel_name:
+            kernel_name = self.parent.config.option.nbval_kernel_name
         else:
             kernel_name = self.nb.metadata.get(
                 'kernelspec', {}).get('name', 'python')

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -112,6 +112,10 @@ def pytest_configure(config):
         from .nbdime_reporter import NbdimeReporter
         reporter = NbdimeReporter(config, sys.stdout)
         config.pluginmanager.register(reporter, 'nbdimereporter')
+    if config.option.nbval or config.option.nbval_lax:
+        if config.option.kernel_name and config.option.current_env:
+            raise ValueError("--current-env and --kernel-name are mutually exclusive.")
+
 
 
 def pytest_collect_file(path, parent):
@@ -232,8 +236,8 @@ class IPyNbFile(pytest.File):
         Called by pytest to setup the collector cells in .
         Here we start a kernel and setup the sanitize patterns.
         """
-        if self.parent.config.option.kernel_name and self.parent.config.option.current_env:
-            raise ValueError("--current-env and --kernel-name are mutually exclusive.")
+        # we've already checked that --current-env and --kernel-name
+        # were not both supplied
         if self.parent.config.option.current_env:
             kernel_name = CURRENT_ENV_KERNEL_NAME
         elif self.parent.config.option.kernel_name:


### PR DESCRIPTION
Fixes #140: adds `--nbval-kernel-name` option.

To do:
  * [x] Figure out how to tell pytest that `--current-env` and `--kernel-name` are mutually exclusive.
  * ~~Add tests.~~ (EDIT: apparently involved/future work)

@vidartf do you happen to know how to tell pytest that two options are mutually exclusive (e.g. as one [can for argparse](https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_mutually_exclusive_group)?

Right now, I just raise an exception during test _execution_ if mutually exclusive options are supplied. That doesn't really make sense! Alternatively, I could raise the exception during test _collection_ -  which is probably a bit better, but ideally the error would happen right at the start (as it would if you were to supply a bogus argument, where you get e.g. `usage: ... unrecognized argument: --bogus`).
