### PR TITLE
Fix warnings in Python 3.8

### DIFF
--- a/nbval/nbdime_reporter.py
+++ b/nbval/nbdime_reporter.py
@@ -25,7 +25,7 @@ from .plugin import IPyNbCell, bcolors
 
 nbdime.log.set_nbdime_log_level('ERROR')
 
-_re_nbval_nodeid = re.compile('.*\.ipynb::Cell \d+')
+_re_nbval_nodeid = re.compile(r'.*\.ipynb::Cell \d+')
 
 
 class NbdimeReporter:

--- a/tests/test_unit_tests_in_notebooks.py
+++ b/tests/test_unit_tests_in_notebooks.py
@@ -66,7 +66,7 @@ def test_print(filename, correctoutcome):
     if correctoutcome == 'pass':
         if exitcode != 0:
             raise AssertionError("Tests failed on ipynb (expected pass)")
-        assert exitcode is 0
+        assert exitcode == 0
         print("The call of py.test has not reported errors - this is good.")
     elif correctoutcome == 'fail':
         if exitcode == 0:


### PR DESCRIPTION
* Fix deprecation warning due to invalid escape sequences.
* Fix syntax warning due to comparison of literals using is.

Fixes #143 