### PR TITLE
Emit content of unexpected stderr

### DIFF
--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -437,12 +437,18 @@ class IPyNbCell(pytest.Item):
             )
             return False
         elif test_keys - ref_keys:
+            extra_keys = test_keys - ref_keys
             self.comparison_traceback.append(
                 cc.FAIL
-                + "Unexpected output fields from running code: %s"
-                % (test_keys - ref_keys)
+                + "Unexpected output fields from running code: %s" % extra_keys
                 + cc.ENDC
-            )
+                + "<<<<<<<<<<<< Unexpected content:"
+                + "\n".join("%s: %s" % (i, testing_outs[i]) for i in extra_keys)
+                + cc.FAIL
+                + '>>>>>>>>>>>>'
+                + cc.ENDC
+                )
+            print('IN STDERR WE GOT: %s' % testing_outs['stderr'])
             return False
 
         # If we've got to here, the two dicts must have the same set of keys


### PR DESCRIPTION
Without this patch, I couldn't really understand where the error was coming from -- turned out to be something in stderr emitted by one of our dependencies which recently got an update. 

Do you think this can be useful?