### PR TITLE
Kernel startup timeout can be set on CLI

### DIFF
--- a/nbval/kernel.py
+++ b/nbval/kernel.py
@@ -75,7 +75,7 @@ class RunningKernel(object):
     this class.
 
     """
-    def __init__(self, kernel_name, cwd=None):
+    def __init__(self, kernel_name, startup_timeout, cwd=None):
         """
         Initialise a new kernel
         specify that matplotlib is inline and connect the stderr.
@@ -83,6 +83,7 @@ class RunningKernel(object):
         """
 
         self.km, self.kc = start_new_kernel(
+            startup_timeout=startup_timeout,
             kernel_name=kernel_name,
             stderr=open(os.devnull, 'w'),
             cwd=cwd,

--- a/nbval/kernel.py
+++ b/nbval/kernel.py
@@ -75,7 +75,7 @@ class RunningKernel(object):
     this class.
 
     """
-    def __init__(self, kernel_name, startup_timeout, cwd=None):
+    def __init__(self, kernel_name, cwd=None, startup_timeout=60):
         """
         Initialise a new kernel
         specify that matplotlib is inline and connect the stderr.

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -93,6 +93,10 @@ def pytest_addoption(parser):
                     type=float,
                     help='Timeout for cell execution, in seconds.')
 
+    group.addoption('--nbval-kernel-startup-timeout', action='store', default=60,
+                    type=float,
+                    help='Timeout for kernel startup, in seconds.')
+
     term_group = parser.getgroup("terminal reporting")
     term_group._addoption(
         '--nbdime', action='store_true',
@@ -234,7 +238,8 @@ class IPyNbFile(pytest.File):
         else:
             kernel_name = self.nb.metadata.get(
                 'kernelspec', {}).get('name', 'python')
-        self.kernel = RunningKernel(kernel_name, str(self.fspath.dirname))
+        self.kernel = RunningKernel(
+            kernel_name, self.config.option.nbval_kernel_startup_timeout, str(self.fspath.dirname))
         self.setup_sanitize_files()
         if getattr(self.parent.config.option, 'cov_source', None):
             setup_coverage(self.parent.config, self.kernel, getattr(self, "fspath", None))

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -239,7 +239,10 @@ class IPyNbFile(pytest.File):
             kernel_name = self.nb.metadata.get(
                 'kernelspec', {}).get('name', 'python')
         self.kernel = RunningKernel(
-            kernel_name, self.config.option.nbval_kernel_startup_timeout, str(self.fspath.dirname))
+            kernel_name,
+            cwd=str(self.fspath.dirname),
+            startup_timeout=self.config.option.nbval_kernel_startup_timeout, 
+        )
         self.setup_sanitize_files()
         if getattr(self.parent.config.option, 'cov_source', None):
             setup_coverage(self.parent.config, self.kernel, getattr(self, "fspath", None))


### PR DESCRIPTION
Using `--nbval-kernel-startup-timeout=VALUE` the respective timeout can be set to a float value, i.e. `'inf'` is also valid.
The previously hard-coded value of 60 (seconds) is kept as default value.

This would close #133.