### PR TITLE
Add "nbval" into --current-env and --sanitize-with option names

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ Specify `-p no:python` if you would like to execute notebooks only. Alternativel
 
     py.test --nbval my_notebook.ipynb
 
-If the output lines are going to be sanitized, an extra flag, `--sanitize-with`
+If the output lines are going to be sanitized, an extra flag, `--nbval-sanitize-with`
 together with the path to a confguration file with regex expressions, must be passed,
 i.e.
 
-    py.test --nbval my_notebook.ipynb --sanitize-with path/to/my_sanitize_file
+    py.test --nbval my_notebook.ipynb --nbval-sanitize-with path/to/my_sanitize_file
 
 where `my_sanitize_file` has the following structure.
 

--- a/dodo.py
+++ b/dodo.py
@@ -22,7 +22,7 @@ def _clean_dist_cmd():
 def task_test():
     return {
         'actions': [
-            _make_cmd(["py.test", "-v", "tests/", "--nbval", "--current-env", "--sanitize-with", "tests/sanitize_defaults.cfg", "--ignore", "tests/ipynb-test-samples"]),
+            _make_cmd(["py.test", "-v", "tests/", "--nbval", "--nbval-current-env", "--nbval-sanitize-with", "tests/sanitize_defaults.cfg", "--ignore", "tests/ipynb-test-samples"]),
         ],
     }
 

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -133,7 +133,6 @@ def pytest_configure(config):
 
 
 
-
 def pytest_collect_file(path, parent):
     """
     Collect IPython notebooks using the specified pytest hook

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -79,12 +79,12 @@ def pytest_addoption(parser):
                     help="Run Jupyter notebooks, only validating output on "
                          "cells marked with # NBVAL_CHECK_OUTPUT")
 
-    group.addoption('--sanitize-with',
+    group.addoption('--nbval-sanitize-with',
                     help='File with regex expressions to sanitize '
                          'the outputs. This option only works when '
                          'the --nbval flag is passed to py.test')
 
-    group.addoption('--current-env', action='store_true',
+    group.addoption('--nbval-current-env', action='store_true',
                     help='Force test execution to use a python kernel in '
                          'the same enviornment that py.test was '
                          'launched from.')
@@ -97,6 +97,12 @@ def pytest_addoption(parser):
                     type=float,
                     help='Timeout for kernel startup, in seconds.')
 
+    group.addoption('--sanitize-with',
+                    help='(deprecated) Alias of --nbval-sanitize-with')
+
+    group.addoption('--current-env', action='store_true',
+                    help='(deprecated) Alias of --nbval-current-env')    
+
     term_group = parser.getgroup("terminal reporting")
     term_group._addoption(
         '--nbdime', action='store_true',
@@ -108,6 +114,16 @@ def pytest_configure(config):
         from .nbdime_reporter import NbdimeReporter
         reporter = NbdimeReporter(config, sys.stdout)
         config.pluginmanager.register(reporter, 'nbdimereporter')
+    if config.option.sanitize_with:
+        warnings.warn("--sanitize-with has been renamed to --nbval-sanitize-with", DeprecationWarning)
+        if config.option.nbval_sanitize_with:
+            raise ValueError("--sanitize-with and --nbval-sanitize-with were both supplied.")
+        config.option.nbval_sanitize_with = config.option.sanitize_with
+    if config.option.current_env:
+        warnings.warn("--current-env has been renamed to --nbval-current-env", DeprecationWarning)
+        if config.option.nbval_current_env:
+            raise ValueError("--current-env and --nbval-current-env were both supplied.")
+        config.option.nbval_current_env = config.option.current_env
 
 
 def pytest_collect_file(path, parent):
@@ -233,7 +249,7 @@ class IPyNbFile(pytest.File):
         Here we start a kernel and setup the sanitize patterns.
         """
 
-        if self.parent.config.option.current_env:
+        if self.parent.config.option.nbval_current_env:
             kernel_name = CURRENT_ENV_KERNEL_NAME
         else:
             kernel_name = self.nb.metadata.get(
@@ -266,8 +282,8 @@ class IPyNbFile(pytest.File):
               this is likely to change in the future
 
         """
-        if self.parent.config.option.sanitize_with is not None:
-            return [self.parent.config.option.sanitize_with]
+        if self.parent.config.option.nbval_sanitize_with is not None:
+            return [self.parent.config.option.nbval_sanitize_with]
         else:
             return []
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,11 +1,11 @@
 PYTEST ?= py.test
-TEST_OPTIONS ?= -v --current-env
+TEST_OPTIONS ?= -v --nbval-current-env
 
 all: test
 
 test:
 	$(PYTEST) $(TEST_OPTIONS) .
-	$(PYTEST) --nbval --current-env --sanitize-with sanitize_defaults.cfg sample_notebook.ipynb
-	$(PYTEST) --nbval --current-env latex-example.ipynb
+	$(PYTEST) --nbval --nbval-current-env --nbval-sanitize-with sanitize_defaults.cfg sample_notebook.ipynb
+	$(PYTEST) --nbval --nbval-current-env latex-example.ipynb
 
 .PHONY: all test

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -44,7 +44,7 @@ def test_collection_nbval(testdir):
     _write_nb(sources, os.path.join(str(testdir.tmpdir), 'test_collection.ipynb'))
 
     # Run tests
-    items, recorder = testdir.inline_genitems('--nbval', '--current-env')
+    items, recorder = testdir.inline_genitems('--nbval', '--nbval-current-env')
 
     # Debug output:
     for item in items:
@@ -60,7 +60,7 @@ def test_collection_nbval_lax(testdir):
     _write_nb(sources, os.path.join(str(testdir.tmpdir), 'test_collection.ipynb'))
 
     # Run tests
-    items, recorder = testdir.inline_genitems('--nbval-lax', '--current-env')
+    items, recorder = testdir.inline_genitems('--nbval-lax', '--nbval-current-env')
 
     # Debug output:
     for item in items:

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -46,7 +46,7 @@ def test_coverage(testdir):
         str(testdir.tmpdir), 'test_coverage.ipynb'))
 
     # Run tests
-    result = testdir.runpytest_inprocess('--nbval', '--current-env', '--cov', '.')
+    result = testdir.runpytest_inprocess('--nbval', '--nbval-current-env', '--cov', '.')
 
     # Check tests went off as they should:
     assert result.ret == 0

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -51,7 +51,7 @@ def test_conf_ignore_stderr(testdir):
         str(testdir.tmpdir), 'test_ignore.ipynb'))
 
     # Run tests
-    result = testdir.runpytest_subprocess('--nbval', '--current-env', '.')
+    result = testdir.runpytest_subprocess('--nbval', '--nbval-current-env', '.')
 
     # Check tests went off as they should:
     assert result.ret == 0

--- a/tests/test_timeouts.py
+++ b/tests/test_timeouts.py
@@ -46,7 +46,7 @@ def test_timeouts(testdir):
         str(testdir.tmpdir), 'test_timeouts.ipynb'))
 
     # Run tests
-    result = testdir.inline_run('--nbval', '--current-env', '--nbval-cell-timeout', '5', '-s')
+    result = testdir.inline_run('--nbval', '--nbval-current-env', '--nbval-cell-timeout', '5', '-s')
     reports = result.getreports('pytest_runtest_logreport')
 
     # Setup and teardown of cells should have no issues:

--- a/tests/test_unit_tests_in_notebooks.py
+++ b/tests/test_unit_tests_in_notebooks.py
@@ -53,7 +53,7 @@ testnames, testdata = create_test_cases_from_filenames()
 @pytest.mark.parametrize("filename, correctoutcome", testdata, ids=testnames)
 def test_print(filename, correctoutcome):
 
-    command = ["py.test", "--nbval", "-v", "--current-env", filename]
+    command = ["py.test", "--nbval", "-v", "--nbval-current-env", filename]
     print("Starting parametrized test with filename={}, correctoutcome={}"
           .format(filename, correctoutcome))
     print("Command about to execute is '{}'".format(command))


### PR DESCRIPTION
Based on some previous discussion, I've added `--nbval-current-env` and `--nbval-sanitize-with` (and kept the old versions with deprecation warnings) to see how it looks.

Upsides:

* consistency with other nbval options
* consistency with other pytest plugins in general? maybe?

Downsides: 

* longer names (https://github.com/computationalmodelling/nbval/pull/141#issuecomment-630083822)
* annoying existing users (deprecation warnings, then having to act)
* more code & docs (for a while)

Here's my summary of the discussion on this topic in #141:

ceball:
> Also, is there a reason/convention behind which options are prefixed with nbval and which aren't?

takluyver:
> There's no real logic behind some of the options not having a prefix nbval. I think any new options we make should be prefixed, and maybe we should define prefixed aliases of the existing options.

ceball:
> Consistency seems good. I have never understood what the convention is for pytest plugins: prefix all a plugin's options, or not? Based on the current output of my pytest --help, at least "cov" and "log" seem to have "cov" and "log" in every option (and almost always as a prefix).

vidartf:
> New flags + old flags aliasing (ideally with a deprecation warning) sounds like a good solution
>
> If I were to play devil's advocate, one argument against longer arguments name is that they end up being hard to remember/type, so you end up always putting the command behind a script / putting the args in setup.cfg, or alternatively always calling pytest --help every time you use nbval.

