### PR TITLE
Add support for pytest>=0.5.0 to nbdime_reporter.py

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -27,7 +27,7 @@ def task_test():
     }
 
 def task_install_test_deps():
-    test_deps = ['matplotlib', 'sympy', 'pytest-cov']
+    test_deps = ['matplotlib', 'sympy', 'pytest-cov', 'pytest-mock', 'nbdime']
     return {
         'actions': [_make_cmd(['pip', 'install'] + test_deps)],
     }

--- a/nbval/nbdime_reporter.py
+++ b/nbval/nbdime_reporter.py
@@ -7,8 +7,18 @@ Authors: V.T. Fauske
 
 # import the pytest API
 import pytest
-from _pytest.main import EXIT_OK, EXIT_TESTSFAILED, EXIT_INTERRUPTED, \
-    EXIT_USAGEERROR, EXIT_NOTESTSCOLLECTED
+try:
+    from _pytest.main import ExitCode
+    EXIT_OK = ExitCode.OK
+    EXIT_TESTSFAILED = ExitCode.TESTS_FAILED
+    EXIT_INTERRUPTED = ExitCode.INTERRUPTED
+    EXIT_USAGEERROR = ExitCode.USAGE_ERROR
+    EXIT_NOTESTSCOLLECTED = ExitCode.NO_TESTS_COLLECTED
+except ImportError:
+    # pytest < 0.5.0
+    from _pytest.main import EXIT_OK, EXIT_TESTSFAILED, EXIT_INTERRUPTED, \
+        EXIT_USAGEERROR, EXIT_NOTESTSCOLLECTED
+
 
 import re
 import copy

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     },
     install_requires = [
         'pytest >= 2.8',
-        'pytest-mock',
         'jupyter_client',
         'nbformat',
         'ipykernel',

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     },
     install_requires = [
         'pytest >= 2.8',
+        'pytest-mock',
         'jupyter_client',
         'nbformat',
         'ipykernel',

--- a/tests/test_nbdime_reporter.py
+++ b/tests/test_nbdime_reporter.py
@@ -1,0 +1,32 @@
+
+from utils import build_nb, add_expected_plaintext_outputs
+
+import nbdime
+import nbformat
+import os
+
+
+def test_nbdime(testdir, mocker):
+
+    # Make a test notebook where output doesn't match input
+    nb = build_nb(["1+1", "1+1"], mark_run=True)
+    add_expected_plaintext_outputs(nb, ["2", "3"])
+    # Write notebook to test dir
+    filename = 'test_nbdime.ipynb'
+    nbformat.write(nb, os.path.join(str(testdir.tmpdir), filename))
+
+    # patch the run_server function so that it doesn't actually
+    # spawn a server and display the diff.  But the diff is still
+    # calculated.
+    mocker.patch('nbdime.webapp.nbdiffweb.run_server')
+    result = testdir.runpytest_inprocess('--nbval',
+                                         '--nbval-current-env',
+                                         '--nbdime',
+                                         filename)
+    # run_server() is only called if there is a discrepancy in the notebook.
+    # so it should have been called in this case:
+    nbdime.webapp.nbdiffweb.run_server.assert_called_once()
+
+    # note: this import must be AFTER the mocker.patch
+    from nbval.nbdime_reporter import EXIT_TESTSFAILED
+    assert result.ret == EXIT_TESTSFAILED


### PR DESCRIPTION
`nbdime_reporter.py` errors for pytest>0.5.0 because pytest changed the error codes to be housed in an Enum (see
https://github.com/pytest-dev/pytest/commit/2b92fee1c315469c3f257673a508e51a1f1a6230#diff-7191acb1a6aaab2f77b6e53ce837e348):


```
(rdtools-dev) C:\Users\KANDERSO\projects\rdtools>pytest --nbval --nbdime
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "c:\users\kanderso\software\anaconda3\envs\rdtools-dev\lib\site-packages\_pytest\main.py", line 265, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>   File "c:\users\kanderso\software\anaconda3\envs\rdtools-dev\lib\site-packages\_pytest\config\__init__.py", line 982, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>   File "c:\users\kanderso\software\anaconda3\envs\rdtools-dev\lib\site-packages\pluggy\hooks.py", line 308, in call_historic
INTERNALERROR>     res = self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "c:\users\kanderso\software\anaconda3\envs\rdtools-dev\lib\site-packages\pluggy\manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "c:\users\kanderso\software\anaconda3\envs\rdtools-dev\lib\site-packages\pluggy\manager.py", line 87, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "c:\users\kanderso\software\anaconda3\envs\rdtools-dev\lib\site-packages\pluggy\callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "c:\users\kanderso\software\anaconda3\envs\rdtools-dev\lib\site-packages\pluggy\callers.py", line 80, in get_result
INTERNALERROR>     raise ex[1].with_traceback(ex[2])
INTERNALERROR>   File "c:\users\kanderso\software\anaconda3\envs\rdtools-dev\lib\site-packages\pluggy\callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "c:\users\kanderso\software\anaconda3\envs\rdtools-dev\lib\site-packages\nbval\plugin.py", line 104, in pytest_configure
INTERNALERROR>     from .nbdime_reporter import NbdimeReporter
INTERNALERROR>   File "c:\users\kanderso\software\anaconda3\envs\rdtools-dev\lib\site-packages\_pytest\assertion\rewrite.py", line 170, in exec_module
INTERNALERROR>     exec(co, module.__dict__)
INTERNALERROR>   File "c:\users\kanderso\software\anaconda3\envs\rdtools-dev\lib\site-packages\nbval\nbdime_reporter.py", line 10, in <module>
INTERNALERROR>     from _pytest.main import EXIT_OK, EXIT_TESTSFAILED, EXIT_INTERRUPTED, \
INTERNALERROR> ImportError: cannot import name 'EXIT_OK' from '_pytest.main' (c:\users\kanderso\software\anaconda3\envs\rdtools-dev\lib\site-packages\_pytest\main.py)
```

This PR gets it working for me locally with pytest 4.6.11, 5.4.1, and 6.2.3.  I would be happy to push up other changes, but I'm not sure what's needed (changelog?  tests?) -- let me know. 