### PR TITLE
Make cell number start at 1 to match IPython/Jupyter

### DIFF
--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -104,7 +104,7 @@ def pytest_addoption(parser):
                     help='(deprecated) Alias of --nbval-sanitize-with')
 
     group.addoption('--current-env', action='store_true',
-                    help='(deprecated) Alias of --nbval-current-env')    
+                    help='(deprecated) Alias of --nbval-current-env')
 
     term_group = parser.getgroup("terminal reporting")
     term_group._addoption(
@@ -267,7 +267,7 @@ class IPyNbFile(pytest.File):
         self.kernel = RunningKernel(
             kernel_name,
             cwd=str(self.fspath.dirname),
-            startup_timeout=self.config.option.nbval_kernel_startup_timeout, 
+            startup_timeout=self.config.option.nbval_kernel_startup_timeout,
         )
         self.setup_sanitize_files()
         if getattr(self.parent.config.option, 'cov_source', None):
@@ -314,7 +314,7 @@ class IPyNbFile(pytest.File):
         self.nb = nbformat.read(str(self.fspath), as_version=4)
 
         # Start the cell count
-        cell_num = 0
+        cell_num = 1
 
         # Iterate over the cells in the notebook
         for cell in self.nb.cells:


### PR DESCRIPTION
## Summary of changes:
* Modified `cell_num` to start at 1 to match IPython/Jupyter output.

See #171 for the issue.

## Pytest Failures

A couple of tests are failing on this branch, but they are also failing on `master` and are unrelated:

```bash
pytest tests/ --nbval --nbval-current-env --nbval-sanitize-with tests/sanitize_defaults.cfg --ignore tests/ipynb-test-samples

...

Results (28.99s):
      40 passed
       2 failed
         - tests/test_coverage.py:14 test_coverage
         - tests/test_ignore.py:18 test_conf_ignore_stderr
       3 skipped
```
