### PR TITLE
Fix docs on skip compare

### DIFF
--- a/docs/source/index.ipynb
+++ b/docs/source/index.ipynb
@@ -568,7 +568,8 @@
    "outputs": [],
    "source": [
     "def pytest_collectstart(collector):\n",
-    "    collector.skip_compare += 'text/html', 'application/javascript', 'stderr',"
+    "    if collector.fspath and collector.fspath.ext == '.ipynb':\n",
+    "        collector.skip_compare += ('text/html', 'application/javascript', 'stderr')\n",
    ]
   }
  ],


### PR DESCRIPTION
As is, the docs on skip_compare error out when running on non notebooks files. I copied the code from the tests to the docs, which does work for me.