### PR TITLE
Fix building docs with nbsphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,10 +43,7 @@ extensions = [
 templates_path = ['_templates']
 
 # The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-#
-# source_suffix = ['.rst', '.md']
-source_suffix = ['.rst', '.ipynb']
+source_suffix = {'.rst': 'restructuredtext'}
 
 # The master toctree document.
 master_doc = 'index'


### PR DESCRIPTION
`.ipynb` shouldn't be included in `source_suffix` like this - this tells Sphinx to treat it as an rst file. I figured it out from [this issue](https://github.com/spatialaudio/nbsphinx/issues/595).

cc @fangohr 