### PR TITLE
sanitize MPL figure size

### DIFF
--- a/tests/sanitize_defaults.cfg
+++ b/tests/sanitize_defaults.cfg
@@ -14,3 +14,7 @@ replace: TIMESTAMP
 [Memory addresses]
 regex: (<[a-zA-Z_][0-9a-zA-Z_.]* at )(0x[0-9a-fA-F]+)(>)
 replace: \1MEMORY_ADDRESS\3
+
+[Matplotlib figure size]
+regex: (Figure size )\d+x\d+( with \d+ Axes)
+replace: \1WIDTHxHEIGHT\2


### PR DESCRIPTION
The default figure size is not hardcoded anymore since matplotlib-inline 0.1.5 (https://github.com/ipython/matplotlib-inline/pull/14), so we need to sanitize for the tests.