### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,48 @@
+name: Release
+
+# always build releases (to make sure wheel-building works)
+# but only publish to PyPI on tags
+on:
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - ".github/workflows/**"
+      - "!.github/workflows/release.yaml"
+  push:
+    paths-ignore:
+      - "docs/**"
+      - ".github/workflows/**"
+      - "!.github/workflows/release.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
+  workflow_dispatch:
+
+jobs:
+  build-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: install build package
+        run: |
+          pip install --upgrade pip
+          pip install build
+          pip freeze
+
+      - name: build release
+        run: |
+          python -m build --sdist --wheel .
+          ls -l dist
+
+      - name: publish to pypi
+        uses: pypa/gh-action-pypi-publish@v1.4.1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
this will publish a release on any tag, allowing anyone with push access to this repo permission to publish releases.

requires someone with PyPI access to add a PyPI upload token called PYPI_PASSWORD in [secrets](https://github.com/computationalmodelling/nbval/settings/secrets/actions/new).