### PR TITLE
Test notebook for cells with a semicolon

### DIFF
--- a/tests/semicolon.ipynb
+++ b/tests/semicolon.ipynb
@@ -1,0 +1,75 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "afdb005e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test():\n",
+    "    return \"hello test\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0220821a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'hello test'"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "34a62f9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe1825a1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This notebook contains a cell where the output is suppressed with a semicolon. Nbval fails for this cell.

The notebook was created with the most recent version of jupyter notebook. It was run from the top, saved and closed.

How to reproduce:

```
pytest --nbval tests/semicolon.ipynb
```

What should happen: The test passes.