### PR TITLE
Don't save coverage setup and teardown to history

### DIFF
--- a/nbval/_cover4.py
+++ b/nbval/_cover4.py
@@ -57,7 +57,7 @@ def setup_coverage(config, kernel, floc, output_loc=None):
 
         # Build setup command and execute in kernel:
         cmd = _python_setup % (data_file, source, config_file)
-        msg_id = kernel.kc.execute(cmd, stop_on_error=False)
+        msg_id = kernel.kc.execute(cmd, stop_on_error=False, store_history=False)
         kernel.await_idle(msg_id, 60)  # A minute should be plenty to enable coverage
     else:
         warnings.warn_explicit(
@@ -78,7 +78,7 @@ def teardown_coverage(config, kernel, output_loc=None):
     language = kernel.language
     if language.startswith('python'):
         # Teardown code does not require any input, simply execute:
-        msg_id = kernel.kc.execute(_python_teardown)
+        msg_id = kernel.kc.execute(_python_teardown, store_history=False)
         kernel.await_idle(msg_id, 60)  # A minute should be plenty to write out coverage
 
         # Ensure we merge our data into parent data of pytest-cov, if possible

--- a/nbval/_cover5.py
+++ b/nbval/_cover5.py
@@ -59,7 +59,7 @@ def setup_coverage(config, kernel, floc, output_loc=None):
 
         # Build setup command and execute in kernel:
         cmd = _python_setup % (data_file, source, config_file)
-        msg_id = kernel.kc.execute(cmd, stop_on_error=False)
+        msg_id = kernel.kc.execute(cmd, stop_on_error=False, store_history=False)
         kernel.await_idle(msg_id, 60)  # A minute should be plenty to enable coverage
     else:
         warnings.warn_explicit(
@@ -80,7 +80,7 @@ def teardown_coverage(config, kernel, output_loc=None):
     language = kernel.language
     if language.startswith('python'):
         # Teardown code does not require any input, simply execute:
-        msg_id = kernel.kc.execute(_python_teardown)
+        msg_id = kernel.kc.execute(_python_teardown, store_history=False)
         kernel.await_idle(msg_id, 60)  # A minute should be plenty to write out coverage
 
     else:


### PR DESCRIPTION
Same reasoning as #190, avoid polluting the input history for interactive frontends.