### PR TITLE
read config in unicode

### DIFF
--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -277,7 +277,7 @@ class IPyNbFile(pytest.File):
         load the contents of the file into the sanitise patterns dictionary.
         """
         for fname in self.get_sanitize_files():
-            with open(fname, 'r') as f:
+            with open(fname, 'r', encoding="utf-8") as f:
                 self.sanitize_patterns.update(get_sanitize_patterns(f.read()))
 
 


### PR DESCRIPTION
UNIX defaults to `utf-8`, but Windows defaults to `cp1252`, [causing errors](https://github.com/tqdm/tqdm/actions/runs/5791157538/job/15695502968). This PR enforces consistency.