### PR TITLE
Switch collection hook to use pathlib paths

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ image: Visual Studio 2019
 # environment variables
 environment:
   matrix:
-    - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"
     - PYTHON: "C:\\Python39-x64"

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,3 +7,4 @@ dependencies:
 - matplotlib
 - sphinx
 - nbsphinx>=0.3.1
+- sphinx-rtd-theme

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -344,13 +344,9 @@ class IPyNbFile(pytest.File):
                 options.update(comment_opts)
                 options.setdefault('check', self.compare_outputs)
                 name = 'Cell ' + str(cell_num)
-                # https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent
-                if hasattr(IPyNbCell, "from_parent"):
-                    yield IPyNbCell.from_parent(
-                        self, name=name, cell_num=cell_num, cell=cell, options=options
-                    )
-                else:
-                    yield IPyNbCell(name, self, cell_num, cell, options)
+                yield IPyNbCell.from_parent(
+                    self, name=name, cell_num=cell_num, cell=cell, options=options
+                )
 
                 # Update 'code' cell count
                 cell_num += 1

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -134,14 +134,14 @@ def pytest_configure(config):
 
 
 
-def pytest_collect_file(collection_path, parent):
+def pytest_collect_file(file_path, parent):
     """
     Collect IPython notebooks using the specified pytest hook
     """
     opt = parent.config.option
-    if (opt.nbval or opt.nbval_lax) and collection_path.suffix == ".ipynb":
+    if (opt.nbval or opt.nbval_lax) and file_path.suffix == ".ipynb":
         # https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent
-        return IPyNbFile.from_parent(parent, path=collection_path)
+        return IPyNbFile.from_parent(parent, path=file_path)
 
 
 comment_markers = {

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -134,21 +134,14 @@ def pytest_configure(config):
 
 
 
-def pytest_collect_file(path, parent):
+def pytest_collect_file(collection_path, parent):
     """
     Collect IPython notebooks using the specified pytest hook
     """
     opt = parent.config.option
-    if (opt.nbval or opt.nbval_lax) and path.fnmatch("*.ipynb"):
+    if (opt.nbval or opt.nbval_lax) and collection_path.suffix == ".ipynb":
         # https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent
-        if hasattr(IPyNbFile, "from_parent"):
-            try:  # Pytest >= 7.0.0
-                return IPyNbFile.from_parent(parent, path=Path(path))
-            except AssertionError:
-                return IPyNbFile.from_parent(parent, fspath=path)
-        else:  # Pytest < 5.4
-            return IPyNbFile(path, parent)
-
+        return IPyNbFile.from_parent(parent, path=collection_path)
 
 
 comment_markers = {

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "mambaforge-23.11"
+    python: "mambaforge-latest"
 
 conda:
   environment: docs/environment.yml

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,13 @@
-type: sphinx
-python:
-  version: 3.8
-  pip_install: true
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "mambaforge-23.11"
+
 conda:
-  file: docs/environment.yml
+  environment: docs/environment.yml
+
+python:
+  install:
+    - method: pip

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -11,3 +11,4 @@ conda:
 python:
   install:
     - method: pip
+      path: .

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'ipykernel',
         'coverage',
     ],
-    python_requires='>=3.6, <4',
+    python_requires='>=3.7, <4',
     classifiers = [
         'Framework :: IPython',
         'Framework :: Pytest',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         ]
     },
     install_requires = [
-        'pytest >= 2.8',
+        'pytest >= 7',
         'jupyter_client',
         'nbformat',
         'ipykernel',


### PR DESCRIPTION
Closes #202.

I've done this the simple way, which requires pytest >= 7. Pytest 7 came out over 2 years ago (February 2022), so I think it's reasonable for a new version of nbval to drop support for older versions.