### PR TITLE
remove failing python 3.8 from appveyor as 3.8 is end of life

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,7 @@ image: Visual Studio 2019
 
 # environment variables
 environment:
-  matrix:
-    - PYTHON: "C:\\Python38-x64"
+  matrix:    
     - PYTHON: "C:\\Python39-x64"
     - PYTHON: "C:\\Python310-x64"
     - PYTHON: "C:\\Python311-x64"


### PR DESCRIPTION
https://ci.appveyor.com/project/takluyver/nbval/builds/51790076

<img width="755" alt="image" src="https://github.com/user-attachments/assets/f8f36064-cf38-4e4e-9503-c1e0444a9ef4" />
