### PR TITLE
ENH: skip rest of file after failure

### DIFF
--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -931,12 +931,11 @@ def _indent(s, indent='  '):
 skip_modules = []
 
 
-@pytest.hookimpl(trylast=True, hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    outcome = yield
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_logreport(report):
 
-    if outcome.get_result().failed:
-        skip_modules.append(item.path)
+    if 'failed' in report.outcome:
+        skip_modules.append(report.fspath)
 
 
 def pytest_runtest_call(item):

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -926,3 +926,19 @@ def _indent(s, indent='  '):
     if isinstance(s, str):
         return '\n'.join(('%s%s' % (indent, line) for line in s.splitlines()))
     return s
+
+
+skip_modules = []
+
+
+@pytest.hookimpl(trylast=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+
+    if outcome.get_result().failed:
+        skip_modules.append(item.path)
+
+
+def pytest_runtest_call(item):
+    if item.path in skip_modules:
+        pytest.skip(f"Due to the previous failure skipping rest of tests in {item.path}")

--- a/nbval/plugin.py
+++ b/nbval/plugin.py
@@ -928,16 +928,16 @@ def _indent(s, indent='  '):
     return s
 
 
-skip_modules = []
+skip_modules = set()
 
 
 @pytest.hookimpl(trylast=True)
 def pytest_runtest_logreport(report):
 
     if 'failed' in report.outcome:
-        skip_modules.append(report.fspath)
+        skip_modules.add(Path(report.fspath).resolve())
 
 
 def pytest_runtest_call(item):
-    if item.path in skip_modules:
+    if Path(item.path) in skip_modules:
         pytest.skip(f"Due to the previous failure skipping rest of tests in {item.path}")


### PR DESCRIPTION
This should address #145 

~Still draft as it doesn't work along with `rerunfailures`, and I don't yet see why.~

TODO checklist:
 - [ ] add option for ini, or maybe also for cli 
 - [ ] make this opt in, currently it's acticated even when `nbval` is not used and one runs pytest on a library
 - [x] make we don't skip the consecutive runs of rerunfailure
 - [ ] ensure that returned traceback is for the first cell failing; this doesn't seem to work when rerunfailure is also used
 - [ ] fixup tests (for unrelated ones I open separate PRs)
 - [ ] add docs
  

And also it will need an option to opt-in (or I would prefer if this would be opt-out, but that means breaking current behaviour).

```
================================================= test session starts ==================================================
platform darwin -- Python 3.12.1, pytest-8.4.0, pluggy-1.6.0
rootdir: /Users/bsipocz/munka/IPAC/navo-workshop
plugins: astropy-0.11.0, remotedata-0.4.1, anyio-4.3.0, custom-exit-code-0.3.0, filter-subpackage-0.2.0, doctestplus-1.4.0, rerunfailures-15.1, astropy-header-0.2.2, dependency-0.6.0, mock-3.14.1, darkgraylib-1.2.1, openfiles-0.6.0, nbval-1.11.0, cov-6.1.1, requests-mock-1.12.1
collected 8 items                                                                                                      

content/reference_notebooks/spectral_access.ipynb ...Fssss                                                       [100%]

...

=============================================== short test summary info ================================================
SKIPPED [4] ../../devel/other/nbval/nbval/plugin.py:943: Due to the previous failure skipping rest of tests in /Users/bsipocz/munka/IPAC/navo-workshop/content/reference_notebooks/spectral_access.ipynb
FAILED content/reference_notebooks/spectral_access.ipynb::Cell 3
======================================== 1 failed, 3 passed, 4 skipped in 7.71s ========================================
```