### PR TITLE
CI: do not run CI in the forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,8 @@ on:
       - "docs/**"
       - ".github/workflows/**"
       - "!.github/workflows/release.yml"
-    branches-ignore:
-      - "dependabot/**"
-      - "pre-commit-ci-update-config"
+    branches:
+      - master
     tags:
       - "**"
   workflow_dispatch:
@@ -27,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,10 @@ name: Tests
 
 on:
   push:
+    branches:
+    - master
+    tags:
+    - '*'
   pull_request:
 
 env:


### PR DESCRIPTION
Currently commits in PRs are double triggering a CI, once in the main repo and once on the forks. 

This PR disables them on the forks, and assumes all development ready for CI is happening in branches that are already attached to PRs.