### PR TITLE
Update license field to use proper SPDX identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     name="nbval",
     version=__version__,
     author="Laslett, Cortes, Fauske, Kluyver, Pepper, Fangohr",
+    license="BSD-3-Clause",
     description='A py.test plugin to validate Jupyter notebooks',
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This changes the license field to be a valid [SPDX identifier](https://spdx.org/licenses) aligning with [PEP 639](https://peps.python.org/pep-0639/#project-source-metadata). This populates the `license_expression` field in the PyPI API which is used by downstream tools including deps.dev

This PR was generated by Claude after reviewing the license and manifest files in repository, but reviewed by me before submitting.